### PR TITLE
allow setting of the JOB_CONFIG variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,11 @@ integration. Please refer to the [DataPusher Settings](https://docs.ckan.org/en/
 
 ### DataPusher+ Configuration
 
-The DataPusher+ instance is configured in the `deployment/datapusher_settings.py` file.
+The DataPusher instance is configured in the `deployment/datapusher_settings.py`
+file. The location of this file can be adjusted using the `JOB_CONFIG`
+environment variable which should provide an absolute path to a python-formatted
+config file.
+
 Here's a summary of the options available.
 
 | Name | Default | Description |

--- a/deployment/datapusher.wsgi
+++ b/deployment/datapusher.wsgi
@@ -4,7 +4,8 @@ import ckanserviceprovider.web as web
 config_filepath = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), 'datapusher_settings.py')
 
-os.environ['JOB_CONFIG'] = config_filepath
+if 'JOB_CONFIG' not in os.environ:
+    os.environ['JOB_CONFIG'] = config_filepath
 
 web.init()
 


### PR DESCRIPTION
ported from a PR to original `datapusher`. It allows setting the location of the settings file, which results quite useful for managing settings as a file but does not interfere with current settings from environment variables if `JOB_CONFIG` is not set.