### PR TITLE
use `qsv input` instead of just `qsv validate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Here's a summary of the options available.
 | TYPE_MAPPING | {'String': 'text', 'Integer': 'numeric', 'Float': 'numeric', 'DateTime': 'timestamp', 'Date': 'timestamp', 'NULL': 'text'} | Internal qsv type mapping |
 | LOG_FILE | `/tmp/ckan_service.log` | Where to write the logs. Use an empty string to disable |
 | STDERR | `True` | Log to stderr? |
-| QSV_BIN | /usr/local/bin/qsvlite | The location of the qsv binary to use |
+| QSV_BIN | /usr/local/bin/qsvdp | The location of the qsv binary to use |
 | PREVIEW_ROWS | 1000 | The number of rows to insert to the data store. Set to 0 to insert all rows |
 | DEFAULT_EXCEL_SHEET | 0 | The zero-based index of the Excel sheet to export to CSV and insert into the Datastore. Negative values are accepted, i.e. -1 is the last sheet, -2 is 2nd to the last, etc. |
 | WRITE_ENGINE_URL | | The Postgres connection string to use to write to the Datastore using Postgres COPY. This should be **similar** to your `ckan.datastore.write_url`, except you'll need to specify a new role with SUPERUSER privileges, |

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -422,7 +422,8 @@ def push_to_datastore(task_id, input, dry_run=False):
     format = resource.get('format').upper()
     if format in spreadsheet_extensions:
         # if so, export it as a csv file
-        logger.info('Converting {} sheet {} to CSV...'.format(format, DEFAULT_EXCEL_SHEET))
+        logger.info('Converting {} sheet {} to CSV...'.format(
+            format, DEFAULT_EXCEL_SHEET))
         # first, we need a temporary spreadsheet filename with the right file extension
         # we only need the filename though, that's why we remove/delete it
         # and create a hardlink to the file we got from CKAN
@@ -442,14 +443,18 @@ def push_to_datastore(task_id, input, dry_run=False):
         qsv_spreadsheet.close()
         tmp = qsv_excel_csv
     else:
-        # its a regular CSV. Check if its valid
+        # its a CSV/TSV? Check if its valid and
+        # transcode it to UTF-8 at the same time
+        qsv_input_csv = tempfile.NamedTemporaryFile(suffix='.csv')
+        logger.info('Validating/Transcoding {}...'.format(format))
         try:
-            qsv_excel = subprocess.run(
-                [QSV_BIN, 'validate', tmp.name], check=True)
+            qsv_input = subprocess.run(
+                [QSV_BIN, 'input', tmp.name, '--output', qsv_input_csv.name], check=True)
         except subprocess.CalledProcessError as e:
             raise util.JobError(
                 'Invalid CSV file: {}'.format(e)
             )
+        tmp = qsv_input_csv
 
     # index csv for speed - count, stats and slice
     # are all accelerated/multithreaded when an index is present
@@ -547,7 +552,7 @@ def push_to_datastore(task_id, input, dry_run=False):
             raise util.JobError(
                 'Cannot create a preview slice: {}'.format(e)
             )
-        tmp = qsv_slice_csv        
+        tmp = qsv_slice_csv
 
     analysis_elapsed = time.perf_counter() - analysis_start
     logger.info(
@@ -627,6 +632,8 @@ def push_to_datastore(task_id, input, dry_run=False):
         qsv_slice_csv.close()
     if 'qsv_excel_csv' in globals():
         qsv_excel_csv.close()
+    if 'qsv_input_csv' in globals():
+        qsv_input_csv.close()
 
     total_elapsed = time.perf_counter() - timer_start
     logger.info(

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -34,7 +34,7 @@ else:
     locale.setlocale(locale.LC_ALL, '')
 
 MAX_CONTENT_LENGTH = web.app.config.get('MAX_CONTENT_LENGTH') or 10485760
-QSV_BIN = web.app.config.get('QSV_BIN') or '/usr/local/bin/qsvlite'
+QSV_BIN = web.app.config.get('QSV_BIN') or '/usr/local/bin/qsvdp'
 PREVIEW_ROWS = web.app.config.get('PREVIEW_ROWS') or 10000
 DEFAULT_EXCEL_SHEET = web.app.config.get('DEFAULT_EXCEL_SHEET') or 0
 CHUNK_SIZE = web.app.config.get('CHUNK_SIZE') or 16384


### PR DESCRIPTION
- input not only checks if a CSV file is well-formed per RFC4180, it transcodes to UTF-8, while being much smaller than the `validate` command.