### PR TITLE
fix import of MutableMapping from collections.abc

### DIFF
--- a/datapusher/config.py
+++ b/datapusher/config.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from typing import get_type_hints, Union
 from dotenv import load_dotenv
 


### PR DESCRIPTION
MutableMapping must be imported like:

`from collections.abc import MutableMapping`

Imports of MutableMapping like
`from collections import MutableMapping`
have been deprecated since Python >=3.3 and will not work in Python >= 3.9

This explicit import from abc will prevent datapusher-plus from throwing errors or warnings and should be backwards compatible until Python 3.3