### PR TITLE
Container packaging fixes

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -38,7 +38,7 @@ ENV QSV_RELEASE=0.87.1
 ENV QSV_ARCHIVE=qsv-$QSV_RELEASE-x86_64-unknown-linux-gnu.zip
 RUN cd /tmp && \
     wget https://github.com/jqnatividad/qsv/releases/download/$QSV_RELEASE/$QSV_ARCHIVE && \
-    unzip $QSV_ARCHIVE && mv qsvlite /usr/local/bin/ && rm $QSV_ARCHIVE
+    unzip $QSV_ARCHIVE && mv qsvdp /usr/local/bin/ && rm $QSV_ARCHIVE
 
 # Setup virtual environment for CKAN
 RUN mkdir -p $DATAPUSHER_CONFIG && \

--- a/Containerfile
+++ b/Containerfile
@@ -34,7 +34,7 @@ ENV DATAPUSHER_CONFIG=/etc/ckan/datapusher
 RUN useradd -r -u 900 -m -c "ckan account" -d $DATAPUSHER_HOME -s /bin/false ckan
 
 # Install qsv
-ENV QSV_RELEASE=0.76.3
+ENV QSV_RELEASE=0.87.1
 ENV QSV_ARCHIVE=qsv-$QSV_RELEASE-x86_64-unknown-linux-gnu.zip
 RUN cd /tmp && \
     wget https://github.com/jqnatividad/qsv/releases/download/$QSV_RELEASE/$QSV_ARCHIVE && \

--- a/container/initialize-and-start.sh
+++ b/container/initialize-and-start.sh
@@ -8,9 +8,10 @@ abort () {
   exit 1
 }
 
-# Fail if postgresql is not running
-if ! pg_isready -h "${POSTGRES_HOST}" -U "${POSTGRES_USER}"; then
-    abort "Postgresql not running"
+# Fail if postgresql is not running, if that's in the sqlalchemy connection string
+if echo "${DATAPUSHER_SQLALCHEMY_DATABASE_URI}" | grep -q 'postgres' \
+       && ! psql -l ${DATAPUSHER_SQLALCHEMY_DATABASE_URI} > /dev/null; then
+   abort "Postgresql not running"
 fi
 
 if [ ! -e $UWSGI_FILE ]; then

--- a/datapusher/main.py
+++ b/datapusher/main.py
@@ -1,8 +1,8 @@
 import os
 import ckanserviceprovider.web as web
 
-from datapusher import jobs
-from config import config
+from . import jobs
+from .config import config
 
 # check whether jobs have been imported properly
 assert jobs.push_to_datastore

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         "python-dotenv",
         'ckanserviceprovider == 1.1.0',
         'requests',
-        "psycopg2",
+        "psycopg2-binary",
         'datasize',
         'semver',
         'uwsgi',


### PR DESCRIPTION
Just updated datapusher-plus, and tried out using the Containerfile in the repo instead of sliding it into our own docker image. 

There were a few hurdles, mainly it looks like the Container file wasn't kept up to date. I will note that changing the import style (in https://github.com/dathere/datapusher-plus/commit/6c6dfec7dfd7068e08fd12b75fb3bfdcf6d91b02) might have some changes elsewhere. Normalizing this did fix the errors on datapusher_initdb.

It does still fail to initdb with sqllite, I think that's a permissions issue rather than anything fundamental. But since it's not really supported anymore, I didn't spend too much time on it. 