### PR TITLE
Use single source of configuration

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -29,6 +29,7 @@ ENV DATAPUSHER_HOME=/usr/lib/ckan/datapusher
 ENV DATAPUSHER_CODE=$DATAPUSHER_HOME/code
 ENV DATAPUSHER_VENV=$DATAPUSHER_HOME/venv
 ENV DATAPUSHER_CONFIG=/etc/ckan/datapusher
+ENV JOB_CONFIG=$DATAPUSHER_CODE/datapusher/settings.py
 
 # Create ckan user
 RUN useradd -r -u 900 -m -c "ckan account" -d $DATAPUSHER_HOME -s /bin/false ckan

--- a/datapusher/settings.py
+++ b/datapusher/settings.py
@@ -1,2 +1,1 @@
-WRITE_ENGINE_URL = 'postgresql://ckan_default:pass@localhost/datastore_default'
-SQLALCHEMY_DATABASE_URI = 'postgresql://datapusher_jobs:YOURPASSWORD@localhost/datapusher_jobs'
+from datapusher.config import *


### PR DESCRIPTION
`ckanserviceprovider` pulls config from `JOB_CONFIG`, which is sometimes set to `settings.py` (in `main.py`), and sometimes unset.
This allows all config to be set by environment variables, `.env`, or by mounting something over `config.py`.
