### PR TITLE
add SNIFF_DELIMITER setting

### DIFF
--- a/datapusher/config.py
+++ b/datapusher/config.py
@@ -81,6 +81,8 @@ class DataPusherPlusConfig(MutableMapping):
     UNSAFE_PREFIX: str = "unsafe_"
     RESERVED_COLNAMES: str = "_id"
     
+    SNIFF_DELIMITER: bool = False
+    
     ADD_SUMMARY_STATS_RESOURCE: bool = False
     SUMMARY_STATS_WITH_PREVIEW: bool = False
     SUMMARY_STATS_OPTIONS: str = ""

--- a/datapusher/dot-env.template
+++ b/datapusher/dot-env.template
@@ -102,6 +102,9 @@ SORT_AND_DUPE_CHECK = True
 # sorts the CSV.
 DEDUP = False
 
+# Should QSV attempt to sniff the CSV delimiter automatically?
+SNIFF_DELIMITER = False
+
 # --------- COLUMN HEADER NAME SAFENAMES SETTINGS --------
 # unsafe prefix to use if a column name is found to be "unsafe"
 UNSAFE_PREFIX = unsafe_

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -672,6 +672,11 @@ def push_to_datastore(task_id, input, dry_run=False):
         # Note that we only change the workfile, the resource file itself is unchanged.
 
         # ------------------- Normalize to CSV ---------------------
+        sniff_delimiter = config.get("SNIFF_DELIMITER")
+        if sniff_delimiter:
+            env_sniff_delimiter = None
+        else:
+            env_sniff_delimiter = "QSV_SNIFF_DELIMITER=1"
         qsv_input_csv = tempfile.NamedTemporaryFile(suffix=".csv")
         if format.upper() == "CSV":
             logger.info("Normalizing/UTF-8 transcoding {}...".format(format))
@@ -688,6 +693,7 @@ def push_to_datastore(task_id, input, dry_run=False):
                     qsv_input_csv.name,
                 ],
                 check=True,
+                env=env_sniff_delimiter,
             )
         except subprocess.CalledProcessError as e:
             # return as we can't push an invalid CSV file


### PR DESCRIPTION
leverage qsv's ability to automatically determine the CSV delimiter and use it when normalizing the CSV for further processing

implements #70 