### PR TITLE
caught a missing variable

### DIFF
--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -1578,6 +1578,7 @@ def push_to_datastore(task_id, input, dry_run=False):
             for idx, ele in enumerate(stats_stats.splitlines()[1:], 1)
         ]
 
+        resource_name = resource.get("name")
         stats_resource = {
             "package_id": resource["package_id"],
             "name": resource_name + " - Summary Statistics",


### PR DESCRIPTION
`resource_name` isn't defined at one point before it's referenced, leading to a crash in certain instances. Fixed.