### PR TITLE
import syntax and ckanserviceprovider version

### DIFF
--- a/datapusher/config.py
+++ b/datapusher/config.py
@@ -68,21 +68,21 @@ class DataPusherPlusConfig(MutableMapping):
 
     PREFER_DMY: bool = False
     PREVIEW_ROWS: int = 0
-    
+
     AUTO_INDEX_THRESHOLD: int = 3
     AUTO_UNIQUE_INDEX:bool = True
     AUTO_INDEX_DATES: bool = True
-    
+
     SORT_AND_DUPE_CHECK: bool = True
     DEDUP: bool = False
     DEFAULT_EXCEL_SHEET: int = 0
-    
+
     UNSAFE_PREFIX: str = "unsafe_"
     RESERVED_COLNAMES: str = "_id"
-        
+
     ADD_SUMMARY_STATS_RESOURCE: bool = False
     SUMMARY_STATS_OPTIONS: str = ""
-    
+
     AUTO_ALIAS: bool = True
     AUTO_ALIAS_UNIQUE: bool = False
 

--- a/datapusher/jobs.py
+++ b/datapusher/jobs.py
@@ -29,7 +29,7 @@ from psycopg2 import sql
 
 # CKAN-related imports
 from ckanserviceprovider import web
-from datapusher.config import config
+from .config import config
 
 
 if locale.getdefaultlocale()[0]:
@@ -372,7 +372,7 @@ def push_to_datastore(task_id, input, dry_run=False):
     with tempfile.TemporaryDirectory() as temp_dir:
         return _push_to_datastore(task_id, input, dry_run=dry_run, temp_dir=temp_dir)
 
-    
+
 def _push_to_datastore(task_id, input, dry_run=False, temp_dir=None):
     handler = util.StoringHandler(task_id, input)
     logger = logging.getLogger(task_id)
@@ -669,7 +669,7 @@ def _push_to_datastore(task_id, input, dry_run=False, temp_dir=None):
         # using uchardet to determine encoding
         file_encoding = subprocess.run(
                         [
-                            "uchardet", 
+                            "uchardet",
                             tmp.name
                         ],
                         check=True,

--- a/datapusher/main.py
+++ b/datapusher/main.py
@@ -1,7 +1,7 @@
 import os
 import ckanserviceprovider.web as web
 
-import .jobs
+from . import jobs
 from .config import config
 
 # check whether jobs have been imported properly

--- a/datapusher/main.py
+++ b/datapusher/main.py
@@ -1,8 +1,8 @@
 import os
 import ckanserviceprovider.web as web
 
-from datapusher import jobs
-from config import config
+import .jobs
+from .config import config
 
 # check whether jobs have been imported properly
 assert jobs.push_to_datastore

--- a/datapusher/settings.py
+++ b/datapusher/settings.py
@@ -1,1 +1,1 @@
-from .config import *
+from datapusher.config import *

--- a/datapusher/settings.py
+++ b/datapusher/settings.py
@@ -1,1 +1,1 @@
-from datapusher.config import *
+from .config import *

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     install_requires=[
         "APScheduler == 3.9.1.post1",
         "python-dotenv",
-        'ckanserviceprovider == 1.1.0',
+        'ckanserviceprovider == 1.2.0',
         'requests',
         "psycopg2-binary",
         'datasize',


### PR DESCRIPTION
Hi everyone, it's me again!

So I was trying to build and run the container for datapusher-plus and it failed in two ways:

* first it complained at run time about the import syntax for the internal `config` module from `main`. Indeed: `config` is not a globally registered module and therefore cannot be imported as `config` unless `$CWD` is `datapusher`, which I suspect most of the time is not. This PR fixes that. The fix assumes that this is installed as a python package, probably via `pip install -e` or similar, which is what the readme says anyways. I'm actually wondering how this worked to begin with.
* then it complained about some flask import that doesn't exist in the package flask-login. It turns out this is related to the release of flask 3 and it is fixed in `ckanserviceprovider` 1.2.0 (see https://github.com/ckan/ckan-service-provider/commit/b467d44ee4ca5e79ce254b587a2e4882d058e636).

Thanks!