### PR TITLE
Fix install_requires dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup(
     install_requires=[
         "APScheduler == 3.9.1.post1",
         "python-dotenv",
-        'ckanserviceprovider == 1.2.0',
         'requests',
         "psycopg2-binary",
         'datasize',


### PR DESCRIPTION
### Description

Since `v1.0.0` it is no longer required to have `ckanserviceprovider` as `datapusher-plus` is now designed to work as a normal CKAN plugin.

This PR cleans leftovers in the `setup.py` file that are causing errors when installing with CKAN 2.10 (#144 )