### PR TITLE
Fix MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,5 @@
-include README.markdown
+include README.md
+include LICENSE
+include requirements.txt
+recursive-include ckanext/datapusher_plus *.html *.json *.js *.less *.css *.mo *.yml
+recursive-include ckanext/datapusher_plus/migration *.ini *.py *.mako


### PR DESCRIPTION
We need to update our `MANIFEST.in` file in order for `pip install .` to get all the files required to run migrations (and webassets)

Inspired by: https://github.com/ckan/ckan/blob/master/contrib/cookiecutter/ckan_extension/%7B%7Bcookiecutter.project%7D%7D/MANIFEST.in 

**Note:** Usually we abuse of `pip install -e .` in our scripts, which completely ignore the MANIFEST.in file since it is installed for development.