### PR TITLE
Fix yaml extension in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include README.md
 include LICENSE
 include requirements.txt
-recursive-include ckanext/datapusher_plus *.html *.json *.js *.less *.css *.mo *.yml
+recursive-include ckanext/datapusher_plus *.html *.json *.js *.less *.css *.mo *.yaml
 recursive-include ckanext/datapusher_plus/migration *.ini *.py *.mako


### PR DESCRIPTION
Our config declaration has `*.yaml` extension, because of that it was not being copied properly when executing `pip install .`

This PR fixes the `MANIFEST.in` file to include `*.yaml` instead of `*.yml`