### PR TITLE
Remove obsolete assets

### DIFF
--- a/ckanext/datapusher_plus/templates/package/resource_edit_base.html
+++ b/ckanext/datapusher_plus/templates/package/resource_edit_base.html
@@ -1,15 +1,5 @@
 {% ckan_extends %}
 
-{% block scripts %}
-  {{ super() }}
-  {% asset 'ckanext-datapusher/datapusher' %}
-{% endblock scripts %}
-
-{% block styles %}
-  {{ super() }}
-  {% asset 'ckanext-datapusher/datapusher-css' %}
-{% endblock %}
-
 {% block inner_primary_nav %}
   {{ super() }}
   {{ h.build_nav_icon('datapusher.resource_data', _('DataStore'), id=pkg.name, resource_id=res.id) }}


### PR DESCRIPTION
This will fix #158 .

`datapusher-plus:dev-v1.0` does no longer ship with webassets, so there is no need to call for them.

Let me know if you have other plans and I'm happy to create a new PR.