### PR TITLE
Ensure we are always using the same token setting for datapusher

### DIFF
--- a/ckanext/datapusher_plus/jobs.py
+++ b/ckanext/datapusher_plus/jobs.py
@@ -122,7 +122,6 @@ def delete_resource(resource_id):
 
 
 def datastore_resource_exists(resource_id):
-    from ckanext.datapusher_plus.job_exceptions import JobError
 
     data_dict = {
         "resource_id": resource_id,
@@ -130,7 +129,7 @@ def datastore_resource_exists(resource_id):
         "include_total": False,
     }
 
-    context = {'ignore_auth': True }
+    context = {'ignore_auth': True}
 
     try:
         result = tk.get_action("datastore_search")(context, data_dict)
@@ -232,9 +231,8 @@ def callback_datapusher_hook(result_url, job_dict):
     # api_key_from_job = job_dict.pop("api_key", None)
     # if not api_key:
     #     api_key = api_key_from_job
-    api_token = tk.config.get("ckanext.datapusher_plus.api_token")
+    api_token = utils.get_dp_plus_user_apitoken()
     headers = {"Content-Type": "application/json", "Authorization": api_token}
-
 
     try:
         result = requests.post(
@@ -258,7 +256,7 @@ def datapusher_plus_to_datastore(input):
     """
     job_dict = dict(metadata=input["metadata"], status="running")
     callback_datapusher_hook(
-        result_url=input["result_url"],job_dict=job_dict)
+        result_url=input["result_url"], job_dict=job_dict)
 
     job_id = get_current_job().id
     errored = False
@@ -391,7 +389,8 @@ def _push_to_datastore(task_id, input, dry_run=False, temp_dir=None):
     if resource.get("url_type") == "upload":
         # If this is an uploaded file to CKAN, authenticate the request,
         # otherwise we won't get file from private resources
-        headers["Authorization"] = str(tk.config.get("ckanext.datapusher_plus.api_token"))
+        api_token = utils.get_dp_plus_user_apitoken()
+        headers["Authorization"] = api_token
 
         # If the ckan_url differs from this url, rewrite this url to the ckan
         # url. This can be useful if ckan is behind a firewall.

--- a/ckanext/datapusher_plus/logic/action.py
+++ b/ckanext/datapusher_plus/logic/action.py
@@ -11,7 +11,6 @@ from dateutil.parser import parse as parse_date
 from six.moves.urllib.parse import urljoin
 
 import ckan.lib.helpers as h
-import ckan.lib.api_token as api_token
 import ckan.lib.navl.dictization_functions
 import ckan.logic as logic
 import ckan.plugins as p
@@ -157,7 +156,6 @@ def datapusher_submit(context, data_dict: dict[str, Any]):
         context['session'] = context['model'].meta.create_local_session()
     tk.get_action('task_status_update')(context, task)
 
-    timeout = config.get('ckan.requests.timeout')
     # This setting is checked on startup
     api_token = utils.get_dp_plus_user_apitoken()
     data = {

--- a/ckanext/datapusher_plus/utils.py
+++ b/ckanext/datapusher_plus/utils.py
@@ -74,6 +74,12 @@ def get_dp_plus_user_apitoken():
     method returns the api_token set in the config file and defaults to the
     site_user.
     """
+
+    api_token = tk.config.get("ckan.datapusher_plus.api_token", None)
+    if api_token:
+        return api_token
+
+    # Consider also the CKAN default api_token for backward compatibility
     api_token = tk.config.get("ckan.datapusher.api_token", None)
     if api_token:
         return api_token


### PR DESCRIPTION
It's not clear which token setting is required

This PR:
 - Moves all references to the util `get_dp_plus_user_apitoken`
 - Preserve the default `ckan.datapusher.api_token` and aldo continues using the new setting `ckan.datapusher_plus.api_token`

I'm not sure which one we expect to use.

Also:
 - Small code changes to clean unused imports


