### PR TITLE
Fix iconv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ datapusher/config_local.py
 *.gz
 *.log
 *.pybak*
+
+.vscode


### PR DESCRIPTION
It looks like `iconv` do not work the same for some linux distributions.
I'm having errors in Alpine 3.17 / CKAN 2.10.5 image.
The most basic way to use this command is to capture the output and write it to a file. This may work in more environments.

Also I've found some typos and references to non declared vars (like `QSV_BIN`)