### PR TITLE
feat: zip file support

### DIFF
--- a/ckanext/datapusher_plus/config.py
+++ b/ckanext/datapusher_plus/config.py
@@ -29,6 +29,14 @@ MINIMUM_QSV_VERSION = "4.0.0"
 # DEBUG, INFO, WARNING, ERROR, CRITICAL
 UPLOAD_LOG_LEVEL = tk.config.get("ckanext.datapusher_plus.upload_log_level", "INFO")
 
+# Supported formats
+FORMATS = tk.config.get(
+    "ckanext.datapusher_plus.formats",
+    ["csv", "tsv", "tab", "ssv", "xls", "xlsx", "ods", "geojson", "shp", "zip"],
+)
+if isinstance(FORMATS, str):
+    FORMATS = FORMATS.split()
+
 # PII screening settings
 PII_SCREENING = tk.asbool(tk.config.get("ckanext.datastore_plus.pii_screening", False))
 PII_FOUND_ABORT = tk.asbool(
@@ -55,7 +63,7 @@ MAX_CONTENT_LENGTH = tk.asint(
     tk.config.get("ckanext.datapusher_plus.max_content_length", "5000000")
 )
 CHUNK_SIZE = tk.asint(tk.config.get("ckanext.datapusher_plus.chunk_size", "1048576"))
-DEFAULT_EXCEL_SHEET = tk.asint(tk.config.get("DEFAULT_EXCEL_SHEET", 1))
+DEFAULT_EXCEL_SHEET = tk.asint(tk.config.get("DEFAULT_EXCEL_SHEET", 0))
 SORT_AND_DUPE_CHECK = tk.asbool(
     tk.config.get("ckanext.datapusher_plus.sort_and_dupe_check", True)
 )
@@ -94,7 +102,7 @@ QSV_STATS_STRING_MAX_LENGTH = tk.asint(
 TYPE_MAPPING = json.loads(
     tk.config.get(
         "ckanext.datapusher_plus.type_mapping",
-        '{"String": "text", "Integer": "numeric","Float": "numeric","DateTime": "timestamp","Date": "timestamp","NULL": "text"}',
+        '{"String": "text", "Integer": "numeric","Float": "numeric","DateTime": "timestamp","Date": "date","NULL": "text"}',
     )
 )
 

--- a/ckanext/datapusher_plus/helpers.py
+++ b/ckanext/datapusher_plus/helpers.py
@@ -404,11 +404,10 @@ def extract_zip_or_metadata(
         task_logger: Optional logger to use for logging (if not provided, module logger will be used)
 
     Returns:
-        tuple: (int, str) - (file_count, result_path)
+        tuple: (int, str, str) - (file_count, result_path, unzipped_format)
             - file_count: Number of files in the ZIP
             - result_path: Path to the extracted file or metadata CSV
-            - unzipped_format: Format of the extracted file
-    """
+            - unzipped_format: Format of the extracted file (e.g., "csv", "json", etc.)
     import os
 
     logger = task_logger if task_logger is not None else logger

--- a/ckanext/datapusher_plus/helpers.py
+++ b/ckanext/datapusher_plus/helpers.py
@@ -408,6 +408,7 @@ def extract_zip_or_metadata(
             - file_count: Number of files in the ZIP
             - result_path: Path to the extracted file or metadata CSV
             - unzipped_format: Format of the extracted file (e.g., "csv", "json", etc.)
+    """
     import os
 
     logger = task_logger if task_logger is not None else logger
@@ -447,7 +448,9 @@ def extract_zip_or_metadata(
                     )
 
             # Otherwise, write metadata CSV
-            logger.info(f"ZIP file contains {file_count} file/s. Saving ZIP metadata...")
+            logger.info(
+                f"ZIP file contains {file_count} file/s. Saving ZIP metadata..."
+            )
             with open(result_path, "w", newline="") as csv_file:
                 fieldnames = [
                     "filename",

--- a/ckanext/datapusher_plus/helpers.py
+++ b/ckanext/datapusher_plus/helpers.py
@@ -3,20 +3,24 @@
 
 from __future__ import annotations
 
-
+import os
 import json
+import zipfile
+import csv
 import logging
 import datetime
-from typing import Any
+from pathlib import Path
+from typing import Any, Optional, Union
 
 import ckan.plugins.toolkit as toolkit
 
 from ckanext.datapusher_plus.model import Jobs, Metadata, Logs
 import ckanext.datapusher_plus.job_exceptions as jex
+import ckanext.datapusher_plus.config as conf
 
 _ = toolkit._
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def datapusher_status(resource_id: str):
@@ -310,7 +314,7 @@ def update_job(job_id, job_dict):  # sourcery skip: raise-specific-error
         Jobs.update(jobs_dict)
 
     except Exception as e:
-        log.error("Failed to update job %s: %s", job_id, e)
+        logger.error("Failed to update job %s: %s", job_id, e)
         raise e
 
 
@@ -383,3 +387,118 @@ def delete_api_key(job_id):
 def set_aps_job_id(job_id, aps_job_id):
 
     update_job(job_id, {"aps_job_id": aps_job_id})
+
+
+def extract_zip_or_metadata(
+    zip_path: Union[str, Path],
+    output_dir: Optional[Union[str, Path]] = None,
+    task_logger: Optional[logging.Logger] = None,
+):
+    """
+    Extract metadata from ZIP archive and save to CSV file.
+    If the ZIP file contains only one item of a supported format, extract it directly.
+
+    Args:
+        zip_path: Path to the ZIP file
+        output_dir: Directory to save the extracted or metadata file (defaults to zip_path's directory)
+        task_logger: Optional logger to use for logging (if not provided, module logger will be used)
+
+    Returns:
+        tuple: (int, str) - (file_count, result_path)
+            - file_count: Number of files in the ZIP
+            - result_path: Path to the extracted file or metadata CSV
+            - unzipped_format: Format of the extracted file
+    """
+    import os
+
+    logger = task_logger if task_logger is not None else logger
+
+    if output_dir is None:
+        output_dir = os.path.dirname(zip_path)
+    # Default result path for metadata
+    result_path = os.path.join(output_dir, "zip_metadata.csv")
+
+    try:
+        with zipfile.ZipFile(zip_path, "r") as zip_file:
+            file_list = [info for info in zip_file.infolist() if not info.is_dir()]
+            file_count = len(file_list)
+
+            if file_count == 1:
+                file_info = file_list[0]
+                file_name = file_info.filename
+                file_ext = os.path.splitext(file_name)[1][1:].upper()
+
+                if file_ext in [fmt.upper() for fmt in conf.FORMATS]:
+                    logger.info(
+                        f"ZIP contains a single supported file: {file_name}. Extracting directly for analysis..."
+                    )
+                    # Extract to output_dir with correct extension
+                    result_path = os.path.join(output_dir, f"zip_data.{file_ext}")
+                    with zip_file.open(file_name) as source, open(
+                        result_path, "wb"
+                    ) as target:
+                        target.write(source.read())
+                    logger.debug(
+                        f"Successfully extracted '{file_name}' to '{result_path}'"
+                    )
+                    return file_count, result_path, file_ext
+                else:
+                    logger.warning(
+                        f"ZIP contains a single file that is not supported: {file_name}"
+                    )
+
+            # Otherwise, write metadata CSV
+            logger.info(f"ZIP file contains {file_count} file/s. Saving ZIP metadata...")
+            with open(result_path, "w", newline="") as csv_file:
+                fieldnames = [
+                    "filename",
+                    "compressed_size",
+                    "file_size",
+                    "compression_ratio",
+                    "date_time",
+                    "create_system",
+                    "create_version",
+                    "extract_version",
+                    "flag_bits",
+                    "internal_attr",
+                    "external_attr",
+                    "CRC",
+                    "compress_type",
+                ]
+                writer = csv.DictWriter(csv_file, fieldnames=fieldnames)
+                writer.writeheader()
+                for file_info in file_list:
+                    if file_info.file_size > 0:
+                        compression_ratio = (
+                            file_info.compress_size / file_info.file_size
+                        ) * 100
+                    else:
+                        compression_ratio = 0
+                    date_time = datetime.datetime(*file_info.date_time).strftime(
+                        "%Y-%m-%d %H:%M:%S"
+                    )
+                    writer.writerow(
+                        {
+                            "filename": file_info.filename,
+                            "compressed_size": file_info.compress_size,
+                            "file_size": file_info.file_size,
+                            "compression_ratio": f"{compression_ratio:.2f}%",
+                            "date_time": date_time,
+                            "create_system": file_info.create_system,
+                            "create_version": file_info.create_version,
+                            "extract_version": file_info.extract_version,
+                            "flag_bits": file_info.flag_bits,
+                            "internal_attr": file_info.internal_attr,
+                            "external_attr": file_info.external_attr,
+                            "CRC": file_info.CRC,
+                            "compress_type": file_info.compress_type,
+                        }
+                    )
+                return file_count, result_path, "CSV"
+
+    except zipfile.BadZipFile:
+        logger.error(f"Error: '{zip_path}' is not a valid ZIP file.")
+        return 0, "", ""
+    except Exception as e:
+        logger.error(f"Error: {str(e)}")
+        return 0, "", ""

--- a/ckanext/datapusher_plus/jobs.py
+++ b/ckanext/datapusher_plus/jobs.py
@@ -702,18 +702,21 @@ def _push_to_datastore(task_id, input, dry_run=False, temp_dir=None):
     # ----------------- is it a spreadsheet? ---------------
     # check content type or file extension if its a spreadsheet
     spreadsheet_extensions = ["XLS", "XLSX", "ODS", "XLSM", "XLSB"]
-    format = resource.get("format").upper()
-    if format in spreadsheet_extensions or unzipped_format in spreadsheet_extensions:
+    file_format = resource.get("format").upper()
+    if (
+        file_format in spreadsheet_extensions
+        or unzipped_format in spreadsheet_extensions
+    ):
         # if so, export spreadsheet as a CSV file
         default_excel_sheet = conf.DEFAULT_EXCEL_SHEET
-        format = unzipped_format if unzipped_format != "" else format
+        file_format = unzipped_format if unzipped_format != "" else file_format
         logger.info(
-            "Converting {} sheet {} to CSV...".format(format, default_excel_sheet)
+            "Converting {} sheet {} to CSV...".format(file_format, default_excel_sheet)
         )
         # first, we need a temporary spreadsheet filename with the right file extension
         # we only need the filename though, that's why we remove it
         # and create a hardlink to the file we got from CKAN
-        qsv_spreadsheet = os.path.join(temp_dir, "qsv_spreadsheet." + format)
+        qsv_spreadsheet = os.path.join(temp_dir, "qsv_spreadsheet." + file_format)
         os.link(tmp, qsv_spreadsheet)
 
         # run `qsv excel` and export it to a CSV
@@ -744,7 +747,7 @@ def _push_to_datastore(task_id, input, dry_run=False, temp_dir=None):
             # get some file info and log it by running `file`
             # just in case the file is not actually a spreadsheet or is encrypted
             # so the user has some actionable info
-            file_format = subprocess.run(
+            file_metadata = subprocess.run(
                 [conf.FILE_BIN, qsv_spreadsheet],
                 check=True,
                 capture_output=True,
@@ -753,7 +756,7 @@ def _push_to_datastore(task_id, input, dry_run=False, temp_dir=None):
 
             logger.warning(
                 "Is the file encrypted or is not a spreadsheet?\nFILE ATTRIBUTES: {}".format(
-                    file_format.stdout
+                    file_metadata.stdout
                 )
             )
 

--- a/ckanext/datapusher_plus/plugin.py
+++ b/ckanext/datapusher_plus/plugin.py
@@ -96,7 +96,18 @@ class DatapusherPlusPlugin(p.SingletonPlugin):
                 "No supported formats configured,\
                     using DataPusher Plus internals"
             )
-            supported_formats = ["csv", "xls", "xlsx", "tsv"]
+            supported_formats = [
+                "csv",
+                "xls",
+                "xlsx",
+                "tsv",
+                "ssv",
+                "tab",
+                "ods",
+                "geojson",
+                "shp",
+                "zip",
+            ]
 
         submit = (
             resource_format


### PR DESCRIPTION
- if a zip file contains only one file and that file is a supported format, DP+ goes ahead and processes the unzipped file and pushes it into the datastore
- if a zip file contains many files, it will extract the zip archive metadata for all the files and processes it as a CSV

Also: 
- cleaned up supported formats
- ensure "mean" column in stats is a TEXT, as it's not always a number (when doing mean for Dates)
- corrected default excel sheet to 0, as its a zero-based index