### PR TITLE
"smart" formula spatial functions

### DIFF
--- a/ckanext/datapusher_plus/jinja2_helpers.py
+++ b/ckanext/datapusher_plus/jinja2_helpers.py
@@ -408,7 +408,7 @@ def spatial_extent_feature_collection(
     context: dict,
     name: str = "Inferred Spatial Extent",
     bbox: list[float] = None,
-    type: str = "inferred",
+    feature_type: str = "inferred",
 ) -> str:
     """Convert a bounding box to a namedGeoJSON feature collection.
 
@@ -417,7 +417,7 @@ def spatial_extent_feature_collection(
         bbox: List of floats representing the bounding box [min_lon, min_lat, max_lon, max_lat]
               If the bbox is not provided, the spatial extent of the resource will be used if available
               Otherwise, the bbox will be calculated from the latitude and longitude fields
-        type: Type of the feature, defaults to "calculated"
+        feature_type: Type of the feature, defaults to "inferred"
 
     Returns:
         str: GeoJSON feature collection string
@@ -431,7 +431,7 @@ def spatial_extent_feature_collection(
         '{"type": "FeatureCollection", "features": [{"type": "Feature", "properties":{"name":"Custom Name","type":"inferred"}, "geometry": {"type": "Polygon", "coordinates": [[[-180, -90], [-180, 90], [180, 90], [180, -90], [-180, -90]]]}, "properties": {}}]}
     """
     if bbox:
-        type = "calculated"
+        feature_type = "calculated"
         # validate bbox
         if len(bbox) != 4:
             return None
@@ -456,7 +456,7 @@ def spatial_extent_feature_collection(
                 else:
                     return None
 
-    return f'{{"type": "FeatureCollection", "features": [{{"type": "Feature", "properties": {{"name": "{name}", "type": "{type}"}}, "geometry": {{"type": "Polygon", "coordinates": [[[{bbox[0]},{bbox[1]}], [{bbox[0]},{bbox[3]}], [{bbox[2]},{bbox[3]}], [{bbox[2]},{bbox[1]}], [{bbox[0]},{bbox[1]}]]]}}}}]}}'
+    return f'{{"type": "FeatureCollection", "features": [{{"type": "Feature", "properties": {{"name": "{name}", "type": "{feature_type}"}}, "geometry": {{"type": "Polygon", "coordinates": [[[{bbox[0]},{bbox[1]}], [{bbox[0]},{bbox[3]}], [{bbox[2]},{bbox[3]}], [{bbox[2]},{bbox[1]}], [{bbox[0]},{bbox[1]}]]]}}}}]}}'
 
 
 @pass_context

--- a/ckanext/datapusher_plus/jinja2_helpers.py
+++ b/ckanext/datapusher_plus/jinja2_helpers.py
@@ -312,7 +312,7 @@ def calculate_bbox_area(
     {{ calculate_bbox_area(dpp.spatial_extent.min_lon, dpp.spatial_extent.min_lat, dpp.spatial_extent.max_lon, dpp.spatial_extent.max_lat) }}
     -> 1234.56
     """
-    from math import radians, cos
+    from math import radians, cos, pi
 
     earth_radius = 6371  # km
 
@@ -340,8 +340,9 @@ def calculate_bbox_area(
             max_lon = context.get("dpps").get(lon_field).get("stats").get("max")
             max_lat = context.get("dpps").get(lat_field).get("stats").get("max")
 
-    width = abs(max_lon - min_lon) * cos(radians((min_lat + max_lat) / 2))
-    height = abs(max_lat - min_lat)
+    # Convert degree differences to radians for accurate area calculation
+    width = abs(max_lon - min_lon) * (pi / 180) * cos(radians((min_lat + max_lat) / 2))
+    height = abs(max_lat - min_lat) * (pi / 180)
     return width * height * (earth_radius**2)
 
 

--- a/ckanext/datapusher_plus/jinja2_helpers.py
+++ b/ckanext/datapusher_plus/jinja2_helpers.py
@@ -316,7 +316,7 @@ def calculate_bbox_area(
 
     earth_radius = 6371  # km
 
-    if not min_lon or not min_lat or not max_lon or not max_lat:
+    if min_lon is None or min_lat is None or max_lon is None or max_lat is None:
         bbox = context.get("resource").get("dpp_spatial_extent")
         if bbox:
             # get the min/max coordinates from the spatial extent
@@ -375,7 +375,7 @@ def spatial_extent_wkt(
         >>> spatial_extent_wkt()
         'POLYGON((-180 -90, -180 90, 180 90, 180 -90, -180 -90))'
     """
-    if not min_lon or not min_lat or not max_lon or not max_lat:
+    if min_lon is None or min_lat is None or max_lon is None or max_lat is None:
         bbox = context.get("resource").get("dpp_spatial_extent")
         if bbox:
             # get the min/max coordinates from the spatial extent

--- a/ckanext/datapusher_plus/jinja2_helpers.py
+++ b/ckanext/datapusher_plus/jinja2_helpers.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from jinja2 import DictLoader, Environment, pass_context
 
 import ckanext.datapusher_plus.config as conf
@@ -291,7 +291,7 @@ def calculate_bbox_area(
     min_lat: float = None,
     max_lon: float = None,
     max_lat: float = None,
-) -> float:
+) -> Optional[float]:
     """Calculate approximate area of bounding box in square kilometers
 
     Args:
@@ -352,7 +352,7 @@ def spatial_extent_wkt(
     min_lat: float = None,
     max_lon: float = None,
     max_lat: float = None,
-) -> str:
+) -> Optional[str]:
     """Convert min/max WGS84 coordinates to WKT polygon format.
 
     Args:


### PR DESCRIPTION
will use inferred lat/lon fields or spatial extent when available in the context

used pass_context decorator to automatically get context, instead of passing it manually