### PR TITLE
fix: tmp input was being wrongfully assigned 

### DIFF
--- a/ckanext/datapusher_plus/jobs.py
+++ b/ckanext/datapusher_plus/jobs.py
@@ -723,8 +723,8 @@ def _push_to_datastore(
         qsv_safenames = qsv.safenames(
             tmp, mode="conditional", output_file=qsv_safenames_csv
         )
-    else:
         tmp = qsv_safenames_csv
+    else:
         logger.info("No unsafe header names found...")
 
     # ---------------------- Type Inferencing -----------------------


### PR DESCRIPTION
…even if the CSV had no unsafe column names

fixes #196 