### PR TITLE
refactored SQL-enabled formulas

### DIFF
--- a/ckanext/datapusher_plus/datastore_utils.py
+++ b/ckanext/datapusher_plus/datastore_utils.py
@@ -72,6 +72,17 @@ def datastore_search_sql(sql: str) -> dict:
         raise utils.JobError(f'Error running datastore_search_sql "{sql}": {e}')
 
 
+def datastore_info(resource_id: str) -> dict:
+    """Get datastore info for a resource."""
+    context = {"ignore_auth": True}
+    data_dict = {"id": resource_id}
+    try:
+        result = tk.get_action("datastore_info")(context, data_dict)
+        return result
+    except Exception as e:
+        raise utils.JobError(f'Error getting datastore info for "{resource_id}": {e}')
+
+
 def send_resource_to_datastore(
     resource: dict,
     resource_id: str,


### PR DESCRIPTION
- better registration of SQL-enabled Jinja2 formula helpers
- SQL-enabled Jinja2 formulas that work best with an index log a warning if no index is available
- move Formulae processing last, so Formulas that use SQL indices can take advantage of them if they are created in the Auto-Indexing phase