### PR TITLE
Improved dpp_suggestions check in jobs.py

### DIFF
--- a/ckanext/datapusher_plus/jobs.py
+++ b/ckanext/datapusher_plus/jobs.py
@@ -1215,21 +1215,58 @@ def _push_to_datastore(
         package_id, scheming_yaml_type="dataset"
     )
 
-    # check if package dpp_suggestions field does not exist
-    # and there are "suggestion_formula" keys in the scheming_yaml
-    if "dpp_suggestions" not in package:
-        # Check for suggestion_formula in dataset_fields
-        has_suggestion_formula = any(
-            isinstance(field, dict)
-            and any(key.startswith("suggestion_formula") for key in field.keys())
-            for field in scheming_yaml["dataset_fields"]
+    # Check for suggestion_formula in dataset_fields
+    has_suggestion_formula = any(
+        isinstance(field, dict)
+        and any(key.startswith("suggestion_formula") for key in field.keys())
+        for field in scheming_yaml["dataset_fields"]
+    )
+
+    if has_suggestion_formula:
+
+        logger.info(
+            'Found suggestion formulae in schema'
         )
 
-        if not has_suggestion_formula:
+        # Check for "dpp_suggestions" in scheming_yaml
+        schema_has_dpp_suggestions = any(
+            isinstance(field, dict)
+            and field.get("field_name") == "dpp_suggestions"
+            for field in scheming_yaml["dataset_fields"]
+        )
+        if not schema_has_dpp_suggestions:
             logger.error(
-                '"dpp_suggestions" field required but not found in package to process Suggestion Formulae. Ensure that your scheming.yaml file contains the "dpp_suggestions" field as a json_object.'
+                '"dpp_suggestions" field required but not found in your schema. Ensure that your scheming.yaml file contains the "dpp_suggestions" field as a json_object.'
             )
             return
+        else:
+            logger.info(
+                'Found "dpp_suggestions" field in schema'
+            )
+
+        # add "dpp_suggestions" to package if it does not exist
+        if "dpp_suggestions" not in package:
+
+            logger.warning(
+                'Warning: "dpp_suggestions" field required to process Suggestion Formulae is not found in this package . Adding "dpp_suggestions" to package'
+            )
+
+            try:
+                package["dpp_suggestions"] = {}
+                dsu.patch_package(package)
+                logger.error(
+                    '"dpp_suggestions" field added to package'
+                )
+                
+            except Exception as e:
+                logger.error(
+                    'Error adding "dpp_suggestions" field {}'.format( e )
+                )
+                return
+    else:
+        logger.info(
+            'No suggestion formulae found'
+        )
 
     logger.trace(f"package: {package}")
 


### PR DESCRIPTION
To avoid situation where DP+ processing bails out early I have modified the way it checks for the existence of suggestion formula.

In the case where formulae exist and dpp_suggestions is in the schema but not the package, dpp_suggestions is added to the package and processing continues.

This is the logic ... 

- Check for suggestion formulae in package
  - If exist, then
    - Check for dpp_suggestions in schema
    - If not exists
      - bail out
    - else
      - Check for dpp_sugestions in package
      - If not exists
        - package_patch to add dpp_suggestions
      - Else
        - continue
  - Else
    - continue