### PR TITLE
Update dataset-druf.yaml

### DIFF
--- a/ckanext/datapusher_plus/dataset-druf.yaml
+++ b/ckanext/datapusher_plus/dataset-druf.yaml
@@ -90,11 +90,25 @@ resource_fields:
     label: Name
     form_placeholder: eg. January 2011
 
+  - field_name: format
+    label: Format
+    preset: resource_format_autocomplete
+
   - field_name: description
     label: Description
     form_snippet: markdown.html
     form_placeholder: Some useful notes about the data
 
-  - field_name: format
-    label: Format
-    preset: resource_format_autocomplete
+  - field_name: rights
+    label: Rights
+    form_snippet: markdown.html
+    validators: ignore_missing
+
+  - field_name: license
+    label: License
+    validators: ignore_missing
+
+  - field_name: data_dictionary
+    label: Data dictionary
+    validators: ignore_missing
+


### PR DESCRIPTION
Add , "Description" ,“Rights”, “License”, and “Data Dictionary”.... resource fields to dataset-druf.yaml so the Add/Edit Resource form matches data.dathere and fixes the missing Description field issue