### PR TITLE
start proposal to fix error with mean for Date fields

### DIFF
--- a/ckanext/datapusher_plus/jobs.py
+++ b/ckanext/datapusher_plus/jobs.py
@@ -1174,6 +1174,22 @@ def _push_to_datastore(task_id, input, dry_run=False, temp_dir=None):
             if conf.AUTO_INDEX_THRESHOLD:
                 headers_cardinality.append(int(fr.get("cardinality") or 0))
 
+    # Go through the qsv_stats_csv file and ensure the "mean" field is empty for
+    # field of type "Date"
+    new_qsv_stats_csv = os.path.join(temp_dir, "qsv_stats_cleaned.csv")
+    with open(qsv_stats_csv, mode="r") as inp, open(new_qsv_stats_csv, mode="w") as outp:
+        reader = csv.DictReader(inp)
+        fieldnames = reader.fieldnames
+        writer = csv.DictWriter(outp, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in reader:
+            if row["type"] == "Date" or row["type"] == "DateTime":
+                row["mean"] = ""
+            writer.writerow(row)
+    qsv_stats_csv = new_qsv_stats_csv
+    logger.info(f"New qsv_stats_csv types for {qsv_stats_csv}")
+    print(open(qsv_stats_csv).read())
+
     # Get the field stats for each field in the headers list
     existing = datastore_resource_exists(resource_id)
     existing_info = None


### PR DESCRIPTION
Error:
<pre>
        Error: {
            "message": "Could not copy stats data to database: invalid input syntax for type double precision: 
                       \"2025-03-01\"\n
                       CONTEXT: COPY 34f58005-11c1-4263-a43f-876a2a365e6d-druf-stats, line 7, 
                       column mean: \"2025-03-01\"\n
                       "
        }
</pre>

The CSV data for this error is a column with Date values like `2025-03-01`
QSV define it as `Date` field (correct) but then the stats table define the `mean` as `FLOAT`

```sql
CREATE TABLE {} (
                field TEXT,
                type TEXT,
               ...
               mean FLOAT,
               ...
            )
```

The `mean` value is also a string like `2025-03-01`

So we can't save this stats table.

CSV failing example

[errored-date.csv](https://github.com/user-attachments/files/23211934/errored-date.csv)

