### PR TITLE
chore: run Serena onboarding

### DIFF
--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/memories/code_style_conventions.md
+++ b/.serena/memories/code_style_conventions.md
@@ -1,0 +1,53 @@
+# Code Style & Conventions
+
+## Python baseline
+- **Target Python 3.10+** — uses `from __future__ import annotations` throughout.
+- Type hints used widely: `from typing import Any, Optional, Callable, Literal`, etc.
+- Google-style docstrings.
+- `# encoding: utf-8` and `# flake8: noqa: E501` headers in CKAN-style modules.
+
+## Naming
+- `snake_case` for functions and variables.
+- `PascalCase` for classes (e.g. `DatapusherPlusPlugin`, `ProcessingContext`, `BaseStage`).
+- `UPPERCASE` for module-level constants.
+- Stage classes live in `jobs/stages/<concern>.py` and inherit from `BaseStage`.
+
+## Imports
+Order:
+1. Stdlib
+2. Third-party
+3. CKAN (`import ckan.plugins as p`, then `tk = p.toolkit`)
+4. Local (`import ckanext.datapusher_plus.<...> as alias`)
+
+Idioms seen in `plugin.py`:
+```python
+import ckan.plugins as p
+from ckan.plugins import toolkit as tk   # or: tk = p.toolkit
+import ckanext.datapusher_plus.views as views
+import ckanext.datapusher_plus.helpers as dph
+import ckanext.datapusher_plus.logic.action as action
+import ckanext.datapusher_plus.logic.auth as auth
+import ckanext.datapusher_plus.cli as cli
+```
+
+## Logging
+- Standard `logging` module with custom **TRACE level (5)** defined in `logging_utils.py`.
+- Pipeline stages use `ProcessingContext.logger` rather than module-level loggers — keeps per-job context.
+- Prefer f-string log messages.
+
+## Error handling
+- Custom exception hierarchy in `job_exceptions.py`:
+  `DataTooBigError`, `JobError`, `HTTPError`, etc.
+- Raise specific exceptions from those classes instead of generic `Exception`.
+
+## Linting
+- Flake8, with **E501 disabled** project-wide (the `# flake8: noqa: E501` comment is conventional at the top of many files). Long lines are accepted.
+
+## Architectural patterns
+- **Pipeline stage pattern** (v2.0): each stage subclasses `BaseStage` and mutates `ProcessingContext`. Add new behaviour as a new stage, not by extending an existing one. Keep stages single-responsibility.
+- Prefer editing the modular `jobs/` package — `jobs_legacy.py` is kept only for reference.
+- CKAN plugin interfaces are wired in `plugin.py`; new actions go through `logic/action.py` + `logic/schema.py` + `logic/auth.py`.
+
+## Comments
+- Keep comments focused on **why**, not what (per default Claude guidance + project style).
+- Do not create new `*.md`/README files unless explicitly asked.

--- a/.serena/memories/codebase_structure.md
+++ b/.serena/memories/codebase_structure.md
@@ -1,0 +1,99 @@
+# Codebase Structure
+
+## Top-level layout
+```
+/Users/joelnatividad/GitHub/datapusher-plus/
+├── ckanext/datapusher_plus/         # The CKAN extension (main package)
+├── datapusher/                      # Legacy/companion package
+├── tests/                           # pytest suite
+├── docs/                            # dataset_schema.yaml, RESOURCE_FIRST_WORKFLOW.md, SQL helper
+├── images/                          # README screenshots
+├── .github/workflows/               # CI: main.yml (integration), test.yml, codeql, python-publish
+├── pyproject.toml                   # Project metadata + setuptools config
+├── setup.py / setup.cfg / MANIFEST.in
+├── requirements.txt / requirements-dev.txt
+├── dot-env.template                 # Sample env vars
+├── default-pii-regexes.txt          # Default PII regex patterns
+├── test_config.py                   # Tests configuration helper
+├── wsgi.py                          # WSGI entry shim
+├── Containerfile                    # OCI image
+├── CHANGELOG.md / README.md / CONFIG.md / LICENSE
+└── CLAUDE.md                        # Project-specific Claude guidance (read this!)
+```
+
+## Main package: `ckanext/datapusher_plus/`
+```
+plugin.py             # CKAN plugin entry point — DatapusherPlusPlugin (SingletonPlugin)
+config.py             # ~50 ckanext.datapusher_plus.* settings
+config_declaration.yaml # CKAN 2.10+ declarative config
+qsv_utils.py          # QSV CLI wrapper (stats, frequency, type inference, validation)
+jinja2_helpers.py     # FormulaProcessor + custom filters/functions
+datastore_utils.py    # PostgreSQL datastore operations
+spatial_helpers.py    # Shapefile/GeoJSON + geometry simplification
+pii_screening.py      # PII detection with configurable regexes
+helpers.py            # Template helpers for job-status UI in CKAN
+cli.py                # CKAN CLI commands (resubmit, submit)
+logging_utils.py      # Custom TRACE log level (5)
+interfaces.py         # IDataPusher external-plugin hook interface
+job_exceptions.py     # Custom exceptions: DataTooBigError, JobError, HTTPError, ...
+views.py              # Flask blueprints
+druf_view.py          # DRUF-specific view handling
+jobs.py               # (entry / glue)
+jobs_legacy.py        # Old monolithic implementation (kept for reference)
+utils.py
+dataset-druf.yaml
+assets/  templates/   # CKAN static + Jinja templates
+logic/
+  action.py           # datapusher_submit, datapusher_hook, datapusher_status
+  auth.py             # Authorization functions
+  schema.py           # Validation schemas
+model/
+  model.py            # Jobs, Metadata, Logs SQLAlchemy models + get_job_details()
+migration/datapusher_plus/   # Alembic migrations
+jobs/                  # v2.0 modular pipeline (replaces jobs_legacy.py)
+  pipeline.py          # Orchestration entry point: datapusher_plus_to_datastore
+  context.py           # ProcessingContext — shared state across stages
+  utils/               # (helpers used by stages)
+  stages/
+    base.py            # Abstract BaseStage
+    download.py        # Download with retries / proxy / timeout
+    format_converter.py # Excel/ODS/Shapefile/GeoJSON/ZIP → CSV
+    validation.py      # RFC-4180 CSV validation, encoding detection/normalization
+    analysis.py        # QSV-based type inference, summary stats, frequency tables
+    database.py        # PostgreSQL COPY ops, smartint type selection
+    indexing.py        # Auto-index creation based on cardinality / dates
+    formula.py         # Jinja2 formula evaluation
+    metadata.py        # Datastore resource dict updates, dpp_suggestions
+```
+
+## Tests: `tests/`
+```
+test_unit.py           # Unit tests
+test_mocked.py         # Mocked integration
+test_acceptance.py     # End-to-end / acceptance
+test_web.py            # Web endpoint tests
+settings_test.py       # Test settings
+log_analyzer.py        # Helper / analytics
+README.md              # Tests reference (scoring algorithms, CSV schemas, etc.)
+static/                # Test fixtures (static assets)
+custom/                # Custom data files used in CI (FILES_DIR=custom)
+```
+
+## Pipeline architecture (v2.0)
+Entry point `datapusher_plus_to_datastore` (in `jobs/pipeline.py`) orchestrates an ordered sequence of stages from `jobs/stages/`, all subclasses of `BaseStage`. State flows through a shared `ProcessingContext` (`jobs/context.py`) that also holds the per-job logger. Each stage isolates one concern: download → format conversion → validation → analysis → database → indexing → formula evaluation → metadata update.
+
+## Database models (`model/model.py`)
+- `Jobs` — job_id, status, data, error, timestamps
+- `Metadata` — formula evaluation results
+- `Logs` — detailed processing logs
+- `get_job_details()` — retrieval helper
+
+## Formula system
+Three namespaces available in scheming-YAML formulas:
+- `dpps` — per-field summary stats (type, min/max, cardinality, stddev, …)
+- `dppf` — per-field frequency tables (top N values w/ counts)
+- `dpp` — inferred metadata (RECORD_COUNT, DATE_FIELDS, LAT_FIELD, LON_FIELD, …)
+
+Two formula kinds:
+- `formula` — evaluated immediately, assigned to the field.
+- `suggest_formula` — stored in `dpp_suggestions` for UI suggestions.

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,0 +1,26 @@
+# DataPusher+ (datapusher-plus)
+
+## Purpose
+DataPusher+ is a **CKAN extension (v2.0.0)** for ultra-fast, robust data ingestion into CKAN's datastore. It replaces the legacy Datapusher webservice and combines the speed/robustness of `ckanext-xloader` with the data-type guessing of Datapusher — supercharged with metadata inference/suggestion via Jinja2 formulas defined in scheming YAML.
+
+Key differentiators:
+- **Guaranteed type inference** — scans the entire file (not first N rows) via [qsv](https://github.com/dathere/qsv), a Rust CSV toolkit.
+- **PostgreSQL COPY** for direct datastore loading (no API overhead).
+- **Jinja2 formula system** for metadata inference/suggestion (`formula` and `suggest_formula` in scheming YAML).
+- **DRUF** (Dataset Resource Upload First) workflow support.
+- Three formula namespaces available: `dpps` (per-field stats), `dppf` (per-field freq tables), `dpp` (inferred metadata: RECORD_COUNT, DATE_FIELDS, LAT_FIELD, LON_FIELD, etc.).
+- No longer a separate webservice — it is now a full CKAN extension (`ckan.plugins` entry point: `datapusher_plus = ckanext.datapusher_plus.plugin:DatapusherPlusPlugin`).
+
+## Repository
+- GitHub: https://github.com/dathere/datapusher-plus
+- License: AGPL-3.0-or-later
+- Maintainer: datHere Engineering <info@dathere.com>
+- Current branch defaults: `main`
+- This project lives at `/Users/joelnatividad/GitHub/datapusher-plus` on the host (Darwin/macOS).
+
+## External runtime dependencies
+- **Python 3.10, 3.11, 3.12, 3.13** (`requires-python = ">=3.10"`)
+- **qsv v4.0.0+** (path configured via `ckanext.datapusher_plus.qsv_bin`)
+- **CKAN 2.10+** with `ckanext-scheming`
+- **PostgreSQL** datastore
+- **RQ (Redis Queue)** for background job processing

--- a/.serena/memories/serena_usage_notes.md
+++ b/.serena/memories/serena_usage_notes.md
@@ -1,0 +1,27 @@
+# Serena Usage Notes for this Project
+
+## Activation
+Project is named **datapusher-plus** at `/Users/joelnatividad/GitHub/datapusher-plus`. Language: Python only. File encoding: utf-8.
+
+## Preferred entry points for navigation
+- **Plugin entry**: `ckanext/datapusher_plus/plugin.py` → `DatapusherPlusPlugin`
+- **Pipeline entry**: `ckanext/datapusher_plus/jobs/pipeline.py` → `datapusher_plus_to_datastore`
+- **Shared state**: `ckanext/datapusher_plus/jobs/context.py` → `ProcessingContext`
+- **Stage base**: `ckanext/datapusher_plus/jobs/stages/base.py` → `BaseStage`
+- **Actions API surface**: `ckanext/datapusher_plus/logic/action.py` (e.g. `datapusher_submit`, `datapusher_hook`, `datapusher_status`)
+- **Data models**: `ckanext/datapusher_plus/model/model.py` (`Jobs`, `Metadata`, `Logs`)
+
+## Workflow recipes
+- Understanding a CKAN action handler: `find_symbol` with name_path `datapusher_submit` (or other action) in `logic/action.py`, `include_body=True`.
+- Adding a pipeline stage:
+  1. `get_symbols_overview` on `jobs/stages/base.py`.
+  2. `find_symbol` on `BaseStage`, `include_body=True`.
+  3. Create new module under `jobs/stages/` using `replace_symbol_body` on a placeholder, or write a new file with the editor.
+  4. Hook the new stage into the pipeline by editing `jobs/pipeline.py` with `replace_symbol_body` on the orchestration function.
+- Renaming or moving a function: prefer `rename` / `move` Serena tools so all references update. Use `find_referencing_symbols` first to scope blast radius.
+- Inspecting how a CKAN interface is wired: `find_symbol` on `DatapusherPlusPlugin` with `depth=1`, then drill into the method that implements the interface hook (`update_config`, `get_actions`, etc.).
+
+## Known oddities
+- `plugin.py` defines `DatastoreException` twice (lines around the top) — likely vestigial; leave alone unless asked to clean up.
+- `jobs.py` and `jobs_legacy.py` both exist at the package root in addition to the modular `jobs/` package. The legacy module is kept for reference; do not edit it.
+- `# flake8: noqa: E501` is conventional at the top of many modules; preserve when editing.

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,82 @@
+# Suggested Commands
+
+> Host OS: **Darwin (macOS)**. Project root: `/Users/joelnatividad/GitHub/datapusher-plus`.
+
+## Testing
+```bash
+# Run the full test suite
+pytest tests/
+
+# Run one file
+pytest tests/test_unit.py
+
+# Run with coverage of the extension package
+pytest --cov=ckanext/datapusher_plus tests/
+
+# Debug a failure with IPython's pdb (configured globally in setup.cfg)
+pytest --pdbcls=IPython.terminal.debugger:TerminalPdb tests/
+```
+Pytest defaults (from `setup.cfg`): SQLAlchemy and `DeprecationWarning` warnings are filtered; `--pdbcls=IPython.terminal.debugger:TerminalPdb` is preset.
+
+## Installing dependencies
+```bash
+pip install -r requirements.txt          # runtime
+pip install -r requirements-dev.txt      # dev/test extras (pytest, pytest-cov, httpretty)
+pip install -e .                          # editable install of the extension
+pip install -e ".[dev]"                  # editable + dev extras
+```
+
+## CKAN CLI (run inside the CKAN environment)
+```bash
+# Resubmit all resources to datapusher
+ckan -c /etc/ckan/default/ckan.ini datapusher_plus resubmit -y
+
+# Submit one dataset's resources
+ckan -c /etc/ckan/default/ckan.ini datapusher_plus submit {dataset_id}
+
+# Apply Alembic migrations for this extension
+ckan -c /etc/ckan/default/ckan.ini db upgrade -p datapusher_plus
+```
+
+## Linting / formatting
+No formatter is enforced; flake8 is the implicit linter with `E501` disabled. There is **no** project-level `make lint`, `ruff`, or `black` config — match existing style.
+
+## CI
+- Integration workflow: `.github/workflows/main.yml` (manual dispatch; spins up CKAN 2.11 + Solr + Postgres + Redis containers).
+- Unit-test workflow: `.github/workflows/test.yml` (note: this file targets older Python versions — read carefully before relying on it).
+- CodeQL: `.github/workflows/codeql-analysis.yml`.
+- Publish: `.github/workflows/python-publish.yml`.
+
+## Common git operations
+```bash
+git status
+git diff
+git log --oneline -20
+git checkout -b feature/<name>
+gh pr create   # GitHub CLI
+gh pr view <n>
+gh pr checks <n>
+```
+
+## macOS-specific system command notes
+The system is **Darwin**, so a few BSD-vs-GNU gotchas:
+- `sed -i` requires an empty string argument: `sed -i '' 's/foo/bar/' file` (not `sed -i 's/.../'`). Prefer the Edit tool anyway.
+- `find` accepts BSD flags; long-form `-iregex` etc. still work, but `-printf` does not — use `-exec` or `xargs`.
+- `date` flags differ from GNU coreutils (`date -v-1d` for "yesterday" instead of `date -d 'yesterday'`).
+- `readlink -f` is not BSD-native; use `greadlink -f` (from `coreutils`) or `python -c 'import os,sys; print(os.path.realpath(sys.argv[1]))'`.
+- `ls` colors via `ls -G`, not `--color`.
+- Use `pbcopy` / `pbpaste` for clipboard.
+- Prefer `rg` (ripgrep) and `fd` if installed; otherwise `grep -R` / `find`.
+
+## Quick exploration aliases (none configured; standard tools)
+```bash
+ls ckanext/datapusher_plus/
+ls ckanext/datapusher_plus/jobs/stages/
+rg "datapusher_plus_to_datastore" ckanext/   # if rg available
+grep -R "datapusher_plus_to_datastore" ckanext/
+```
+
+## qsv (the runtime dependency)
+- Binary path configured by `ckanext.datapusher_plus.qsv_bin` in `ckan.ini`.
+- Must be **qsv v4.0.0+**. The CI uses `QSV_VER=7.1.0` (set in `main.yml`).
+- Local invocation goes through `ckanext/datapusher_plus/qsv_utils.py`.

--- a/.serena/memories/task_completion_checklist.md
+++ b/.serena/memories/task_completion_checklist.md
@@ -1,0 +1,58 @@
+# Task Completion Checklist
+
+Before declaring a code task "done" on datapusher-plus:
+
+## 1. Run the tests
+```bash
+pytest tests/
+```
+If the change is scoped, run the relevant test file first (e.g. `pytest tests/test_unit.py`), then the full suite if time allows. Use coverage when relevant:
+```bash
+pytest --cov=ckanext/datapusher_plus tests/
+```
+
+## 2. Lint
+There is no enforced formatter. The project uses flake8 with E501 disabled. If you have flake8 installed, run it on touched files:
+```bash
+flake8 ckanext/datapusher_plus/<changed_file>.py --ignore=E501
+```
+Don't introduce trailing whitespace, unused imports, or undefined names.
+
+## 3. Verify symbol-level edits
+When using Serena's symbolic edits (`replace_symbol_body`, `insert_*_symbol`), re-open the file with `get_symbols_overview` afterwards to confirm:
+- No duplicated tails or lost function bodies.
+- Symbol boundaries (decorators, async, type hints) preserved.
+
+## 4. LSP / Serena diagnostics
+After edits, prefer LSP/Serena navigation to confirm references still resolve. If you renamed or moved a symbol, run `find_referencing_symbols` on it and update callers (this project does not enforce backward-compat shims unless asked).
+
+## 5. Pipeline stage changes specifically
+If you touched anything under `ckanext/datapusher_plus/jobs/stages/` or `jobs/pipeline.py`:
+- Confirm `ProcessingContext` invariants still hold (the logger, run-id, paths).
+- Confirm `BaseStage` contract is respected (entry/exit hooks if defined there).
+- Check that `jobs_legacy.py` was NOT modified — it is preserved for reference.
+
+## 6. Database / model changes
+If `model/model.py` changed:
+- Create a new Alembic migration under `ckanext/datapusher_plus/migration/datapusher_plus/`.
+- Document the migration in CHANGELOG.md (only if the user asks).
+
+## 7. Config changes
+If you added a setting:
+- Add it to `config.py`.
+- Declare it in `config_declaration.yaml` (CKAN 2.10+).
+- Reference it from `CONFIG.md` only when the user asks.
+
+## 8. Documentation
+**Do NOT** create or update `*.md` / README files unless the user explicitly asks. The CLAUDE.md in the repo is the source of truth for AI workflow.
+
+## 9. Git
+- Don't commit unless explicitly told to.
+- Don't run `git add -A` / `git add .` — stage by name.
+- Don't push without an explicit request.
+- Never `--amend` published commits; create a new commit instead.
+
+## 10. Sanity check the assumptions
+- New file >10MB inputs? Verify behavior with qsv stats cache (`mcp__qsv__qsv_stats` if testing data wrangling).
+- Did the change cross a Python-version boundary (3.10 → 3.13)? Avoid 3.11-only syntax until verified.
+- Touched CKAN plugin interfaces? Update the `p.implements(...)` list in `plugin.py` to match.

--- a/.serena/memories/tech_stack.md
+++ b/.serena/memories/tech_stack.md
@@ -1,0 +1,36 @@
+# Tech Stack
+
+## Language / Runtime
+- Python 3.10+ (CI tests run inside `ckan/ckan-dev:2.11` container, default CKAN_VERSION=2.11)
+- Targets Python 3.10 / 3.11 / 3.12 / 3.13
+
+## Frameworks / Platforms
+- **CKAN 2.10+** plugin (extends `p.SingletonPlugin`, implements many CKAN interfaces: `IConfigurer`, `IConfigurable`, `IActions`, `IAuthFunctions`, `IPackageController`, `IResourceUrlChange`, `IResourceController`, `ITemplateHelpers`, `IBlueprint`, `IClick`, and conditionally `IFormRedirect`).
+- **Flask** blueprints (`views.py`, `druf_view.py`) for web endpoints.
+- **RQ (Redis Queue)** for background job processing.
+- **PostgreSQL** datastore using direct `COPY` for ingestion.
+- **ckanext-scheming** integration for declarative dataset/resource schemas with Jinja2 formulas.
+
+## Core Libraries (runtime, requirements.txt)
+- `semver==3.0.4`
+- `datasize==1.0.0`
+- `jinja2>=3.1.4`
+- `fiona==1.10.1` (shapefile/geo I/O)
+- `pandas==2.2.3`
+- `shapely==2.1.0`
+- `pyproj>=3.7.1`
+
+## Dev / Test (requirements-dev.txt)
+- `pytest`
+- `pytest-cov`
+- `httpretty==1.1.4`
+
+## External CLI / Tooling
+- **qsv** (Rust-based CSV toolkit) — invoked via `qsv_utils.py`, path is `ckanext.datapusher_plus.qsv_bin`.
+- **GDAL / geospatial system libs** (libxml2, libxslt1, libpq, libgeos, libproj, libspatialindex, gdal-bin, libgdal-dev) — required for `fiona`/`shapely`/`pyproj` in CI; installed via apt in `.github/workflows/main.yml`.
+- **uchardet** — used for encoding detection (installed in CI).
+
+## Build System
+- `setuptools >= 62.6.0` via `pyproject.toml`.
+- Packages discovered with `find` (excluding `tests*`).
+- `requirements.txt` is the dynamic source of dependencies; `requirements-dev.txt` feeds the `dev` optional-dependencies extra.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,154 @@
+# the name by which the project can be referenced within Serena
+project_name: "datapusher-plus"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   haxe                java                julia               kotlin              lua
+#   markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- python
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project based on the project name or path.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
+#       for example by saying that the information retrieved from a memory file is no longer correct
+#       or no longer relevant for the project.
+#  * `edit_memory`: Replaces content matching a regular expression in a memory.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_file`: Finds files in the given relative paths
+#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
+#  * `find_symbol`: Performs a global (or local) search using the language server backend.
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
+#       for clients that do not read the initial instructions when the MCP server is connected.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
+#       is relevant to the current task. You can infer whether the information
+#       is relevant from the memory file name.
+#       You should not read the same memory file multiple times in the same conversation.
+#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
+#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
+#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
+#       For JB, we use a separate tool.
+#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
+#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
+#  * `safe_delete_symbol`:
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
+#       The memory name should be meaningful.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []


### PR DESCRIPTION
## Summary
- Activates Serena for this repo and adds the standard `.serena/` config + memory files generated by the Serena onboarding flow.
- Memories captured: project overview, tech stack, codebase structure, code style/conventions, suggested commands, task-completion checklist, and Serena usage notes specific to this project.
- `.serena/.gitignore` excludes the local cache and per-user `project.local.yml`; only the shared `project.yml` and the curated memory files are committed.

## Test plan
- [x] Confirm `.serena/project.yml` correctly identifies the project as Python.
- [x] Open a new Claude Code session and verify Serena auto-activates and that `mcp__serena__check_onboarding_performed` reports onboarding as already done.
- [x] Spot-check one or two memory files for accuracy against the current `ckanext/datapusher_plus/` layout.

No source code is modified; this is tooling/config only.