### PR TITLE
refactor(prefect): make per-stage result dataclasses self-contained

### DIFF
--- a/.serena/memories/dpp_test_container.md
+++ b/.serena/memories/dpp_test_container.md
@@ -1,0 +1,54 @@
+# `dpp-test` — pre-built ckan-dev container for DP+ work
+
+A persistent Docker container kept around so DP+ tests/builds can run
+without a local CKAN env. **Reuse it for future DP+ work** instead of
+rebuilding.
+
+## What it is
+- Name: `dpp-test`
+- Image: `ckan/ckan-dev:2.11`, started with `--platform linux/amd64`
+  (host is Apple Silicon → amd64 is emulated, so it's slowish).
+- Started with `--user root ... sleep infinity` (image entrypoint bypassed).
+- Repo mounted **live** at `/repo` (host edits are visible immediately;
+  `git checkout` on the host changes what the container sees).
+- CKAN 2.11.5, Python 3.10.20.
+
+## What's installed (took ~5 min, mirrors `.github/workflows/ci.yml`)
+- Geo system libs: `gdal-bin libgdal-dev libspatialindex-dev libgeos-dev
+  libproj-dev` + `build-essential` etc.
+- GDAL python 3.6.2, `requirements.txt` + `requirements-dev.txt`,
+  `pip install -e .` (→ `datapusher-plus 3.0.0a0`, editable).
+- qsv 20.0.0 at `/usr/local/bin/qsvdp`.
+
+## Run the unit suite
+```bash
+docker exec -e PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 -e QSV_BIN=/usr/local/bin/qsvdp \
+  -e CKAN_INI=/srv/app/src/ckan/test-core.ini -w /repo dpp-test \
+  python3 -m pytest tests/ --ignore=tests/integration -o addopts= -p no:cacheprovider -q
+```
+Required env, and why:
+- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` — ckan-dev's site-packages registers a
+  pytest plugin that calls `make_app()` in `pytest_sessionstart`, needing a
+  fully-configured CKAN. Disable autoload so plain pytest runs.
+- `QSV_BIN=/usr/local/bin/qsvdp` — for `test_qsv_v20_regression.py`.
+- `CKAN_INI=/srv/app/src/ckan/test-core.ini` — the image's default
+  `/srv/app/ckan.ini` is NOT populated when the entrypoint is bypassed;
+  `test-core.ini` has a real `SECRET_KEY`.
+- `-o addopts=` — overrides `setup.cfg`'s `--pdbcls=IPython...` addopt.
+- `tests/integration/` excluded — needs the full Prefect+CKAN+Postgres+Solr
+  stack (what `main.yml` / `ci.yml` bring up).
+
+## Known result (as of 2026-05-15)
+**42/43 unit tests pass.** The 1 error
+(`test_flow_completes_and_marks_job_complete`) is pre-existing: the first
+flow test triggers an import-time `_bootstrap_ckan_app_context()` →
+`make_app()` that needs a full CKAN env. See `HANDOFF.md` → *Known
+cosmetic / minor* for the full diagnosis and the deferred fix.
+
+## If the container is gone (Docker restart / removed)
+- Restart: `docker start dpp-test` (state persists across stops).
+- Recreate: `docker run -d --name dpp-test --platform linux/amd64 --user root
+  -v <repo>:/repo -w /repo ckan/ckan-dev:2.11 sleep infinity`, then re-run
+  the `ci.yml`-style install (apt geo libs → `pip install GDAL==$(gdal-config
+  --version)` → `pip install -r requirements.txt -r requirements-dev.txt -e .`
+  → download qsv 20.0.0 musl zip → `qsvdp` to `/usr/local/bin/`).

--- a/ckanext/datapusher_plus/jobs/caching.py
+++ b/ckanext/datapusher_plus/jobs/caching.py
@@ -6,22 +6,25 @@ Result-persistence and cache-key configuration for the Prefect flow.
 is active: every task output is checkpointed so operators can open a
 task's output from the Prefect UI to debug bad data.
 
-**Content-based caching is currently DISABLED.** The cache-key
-functions and policies below are kept for when it can be safely
-re-enabled, but ``prefect_flow.py`` no longer passes ``cache_policy=``
-to any task. The reason: the stage tasks carry their real state
-(headers, file paths, row counts) in the ``RuntimeContext`` shared via
-a ``ContextVar``, *not* in their return-value dataclasses. A cache
-*hit* makes Prefect skip the task body — which is exactly the code that
-populates ``RuntimeContext`` — so a downstream task then reads empty
-state (observed as ``COPY "<table>" () FROM STDIN`` when two resources
-shared identical file content and the second hit the cache).
+**Content-based caching is currently DISABLED** — ``prefect_flow.py``
+does not pass ``cache_policy=`` to any task. The cache-key functions
+and policies below are kept for when it can be safely re-enabled.
 
-Re-enabling caching requires first making each per-stage result
-dataclass fully self-contained (the deferred "ProcessingContext
-retirement" work), so a cache hit reconstitutes everything the next
-task needs from the cached result rather than from shared mutable
-state.
+The original blocker is now cleared: each per-stage result dataclass is
+self-contained (it nests its ``upstream`` result), and every task
+``rehydrate``-s the ``RuntimeContext`` from its input result before
+running its stage. So a cache *hit* — which skips the task body — no
+longer leaves a downstream stage reading empty state (the
+``COPY "<table>" () FROM STDIN`` failure that first forced caching off).
+
+What still blocks re-enabling it: the result dataclasses carry working
+*file paths* (``downloaded_path``, ``csv_path``) that point into a
+per-flow-run ``TemporaryDirectory``. A cached result from an earlier
+run references a tempdir that no longer exists, so the consuming stage
+would fail on a missing file. Safely re-enabling content caching needs
+the working files persisted to stable ``result_storage`` (and rehydra-
+tion to stage them back into the current tempdir) — the next step of
+the ProcessingContext-retirement work.
 """
 
 from __future__ import annotations
@@ -122,10 +125,10 @@ def download_cache_key(context, parameters) -> Optional[str]:
 def content_cache_key(context, parameters) -> Optional[str]:
     """Cache by the content fingerprint propagated through the chain.
 
-    Each downstream result dataclass exposes a ``file_hash`` field that
-    each task copies forward from its input. When the upstream content is
-    identical across runs, every read-only stage finds its cached output
-    and skips the qsv subprocess.
+    Each downstream result dataclass exposes a ``file_hash`` property that
+    walks its ``upstream`` chain to the root ``DownloadResult``. When the
+    upstream content is identical across runs, every read-only stage finds
+    its cached output and skips the qsv subprocess.
 
     Returns ``None`` (no cache) when the propagated hash is missing —
     safer than caching by path, which would silently miss across runs.

--- a/ckanext/datapusher_plus/jobs/caching.py
+++ b/ckanext/datapusher_plus/jobs/caching.py
@@ -125,10 +125,18 @@ def download_cache_key(context, parameters) -> Optional[str]:
 def content_cache_key(context, parameters) -> Optional[str]:
     """Cache by the content fingerprint propagated through the chain.
 
-    Each downstream result dataclass exposes a ``file_hash`` property that
-    walks its ``upstream`` chain to the root ``DownloadResult``. When the
-    upstream content is identical across runs, every read-only stage finds
-    its cached output and skips the qsv subprocess.
+    The read-only-stage results (``ConvertResult``, ``ValidateResult``,
+    ``AnalyzeResult``) expose a ``file_hash`` property that walks the
+    ``upstream`` chain to the root ``DownloadResult`` — these are the
+    candidates for content caching. ``DatabaseResult`` exposes it too for
+    chain-traversal symmetry, though the database task is side-effecting
+    and not itself cached. The terminal side-effecting results
+    (``IndexingResult`` / ``FormulaResult`` / ``MetadataResult``)
+    intentionally don't expose ``file_hash``: caching their outputs would
+    skip the actual side effect.
+
+    When the upstream content is identical across runs, every read-only
+    stage finds its cached output and skips the qsv subprocess.
 
     Returns ``None`` (no cache) when the propagated hash is missing —
     safer than caching by path, which would silently miss across runs.

--- a/ckanext/datapusher_plus/jobs/prefect_flow.py
+++ b/ckanext/datapusher_plus/jobs/prefect_flow.py
@@ -186,6 +186,7 @@ from ckanext.datapusher_plus.jobs.runtime_context import (
     RuntimeContext,
     ValidateResult,
     get_runtime_context,
+    rehydrate,
     reset_runtime_context,
     set_runtime_context,
 )
@@ -340,14 +341,23 @@ class _StageAbort(Exception):
         )
 
 
-def _stage_run(stage) -> RuntimeContext:
+def _stage_run(stage, prev: Any = None) -> RuntimeContext:
     """Invoke a stage on the bound RuntimeContext.
+
+    ``prev`` is the upstream task's result. When given, the bound
+    ``RuntimeContext`` is rehydrated from it first, so the stage sees
+    correct ``ctx`` state even if the upstream task's body never ran (a
+    Prefect cache hit, or a persisted-result replay on a flow re-run) —
+    that body is what would otherwise have mutated the shared context.
+    The root task (``download_task``) passes no ``prev``.
 
     A stage returning ``None`` is the BaseStage "skip / nothing to do"
     signal (per its docstring) — surfaced here as ``_StageAbort`` so the
     flow can stop cleanly and mark the job *complete*, not errored.
     """
     ctx = get_runtime_context()
+    if prev is not None:
+        rehydrate(ctx, prev)
     result = stage(ctx)
     if result is None:
         raise _StageAbort(stage.name)
@@ -447,11 +457,11 @@ def download_task(job_input: JobInput) -> DownloadResult:
 )
 def format_convert_task(prev: DownloadResult) -> ConvertResult:
     """Excel/ODS/Shapefile/GeoJSON/ZIP → CSV via qsv."""
-    ctx = _stage_run(FormatConverterStage())
+    ctx = _stage_run(FormatConverterStage(), prev)
     return ConvertResult(
+        upstream=prev,
         csv_path=ctx.tmp,
         converted_from=ctx.resource.get("format"),
-        file_hash=prev.file_hash,
     )
 
 
@@ -464,7 +474,7 @@ def format_convert_task(prev: DownloadResult) -> ConvertResult:
 )
 def validate_task(prev: ConvertResult) -> ValidateResult:
     """RFC-4180 validation with quarantine, encoding normalization, dedup."""
-    ctx = _stage_run(ValidationStage())
+    ctx = _stage_run(ValidationStage(), prev)
 
     # Enforce the quarantine threshold (raises if exceeded) and emit the
     # row.quarantined event. ``apply_quarantine`` is a no-op when no rows
@@ -478,11 +488,11 @@ def validate_task(prev: ConvertResult) -> ValidateResult:
     )
 
     return ValidateResult(
+        upstream=prev,
         csv_path=ctx.tmp,
         rows_after_dedup=ctx.rows_to_copy,
         quarantined_rows=ctx.quarantined_rows,
         quarantine_csv_path=ctx.quarantine_csv_path or None,
-        file_hash=prev.file_hash,
     )
 
 
@@ -497,7 +507,7 @@ def validate_task(prev: ConvertResult) -> ValidateResult:
 )
 def analyze_task(prev: ValidateResult) -> AnalyzeResult:
     """qsv stats + frequency + type inference + PII screening."""
-    ctx = _stage_run(AnalysisStage())
+    ctx = _stage_run(AnalysisStage(), prev)
     if ctx.pii_found:
         # Operators wire Prefect Automations to this event for alerting.
         # PII screening reports a candidate-match count, not per-column
@@ -508,6 +518,8 @@ def analyze_task(prev: ValidateResult) -> AnalyzeResult:
             details={"candidate_count": ctx.pii_candidate_count},
         )
     return AnalyzeResult(
+        upstream=prev,
+        csv_path=ctx.tmp,
         headers=list(ctx.headers),
         headers_dicts=list(ctx.headers_dicts),
         original_header_dict=dict(ctx.original_header_dict),
@@ -516,7 +528,6 @@ def analyze_task(prev: ValidateResult) -> AnalyzeResult:
         resource_fields_freqs=dict(ctx.resource_fields_freqs),
         pii_found=ctx.pii_found,
         pii_candidate_count=ctx.pii_candidate_count,
-        file_hash=prev.file_hash,
     )
 
 
@@ -534,8 +545,9 @@ def analyze_task(prev: ValidateResult) -> AnalyzeResult:
 )
 def database_task(prev: AnalyzeResult) -> DatabaseResult:
     """Postgres COPY into the datastore."""
-    ctx = _stage_run(DatabaseStage())
+    ctx = _stage_run(DatabaseStage(), prev)
     return DatabaseResult(
+        upstream=prev,
         rows_to_copy=ctx.rows_to_copy,
         copied_count=ctx.copied_count,
         existing_info=dict(ctx.existing_info) if ctx.existing_info else None,
@@ -554,8 +566,8 @@ def database_task(prev: AnalyzeResult) -> DatabaseResult:
 )
 def indexing_task(prev: DatabaseResult) -> IndexingResult:
     """Create indexes based on cardinality / date columns."""
-    _stage_run(IndexingStage())
-    return IndexingResult()
+    _stage_run(IndexingStage(), prev)
+    return IndexingResult(upstream=prev)
 
 
 @task(
@@ -569,8 +581,8 @@ def indexing_task(prev: DatabaseResult) -> IndexingResult:
 )
 def formula_task(prev: IndexingResult) -> FormulaResult:
     """Jinja2 formula evaluation against dpps/dppf/dpp namespaces."""
-    _stage_run(FormulaStage())
-    return FormulaResult()
+    _stage_run(FormulaStage(), prev)
+    return FormulaResult(upstream=prev)
 
 
 @task(
@@ -586,8 +598,8 @@ def formula_task(prev: IndexingResult) -> FormulaResult:
 )
 def metadata_task(prev: FormulaResult) -> MetadataResult:
     """Final datastore resource_show updates + dpp_suggestions write-back."""
-    _stage_run(MetadataStage())
-    return MetadataResult()
+    _stage_run(MetadataStage(), prev)
+    return MetadataResult(upstream=prev)
 
 
 
@@ -1021,6 +1033,12 @@ def datapusher_plus_flow(job_input: JobInput) -> Optional[str]:
                 idx = indexing_task(db)
                 fm = formula_task(idx)
                 md = metadata_task(fm)
+
+            # The result chain is the source of truth: derive the flow's
+            # final view of ``runtime`` from the terminal result so the
+            # artifact / event / completion code below is correct even if
+            # a task body was skipped (cache hit / persisted-result replay).
+            rehydrate(runtime, md)
 
             if job_input.dry_run:
                 dph.mark_job_as_completed(

--- a/ckanext/datapusher_plus/jobs/runtime_context.py
+++ b/ckanext/datapusher_plus/jobs/runtime_context.py
@@ -252,7 +252,12 @@ def _apply_result(ctx: RuntimeContext, result: Any) -> None:
     stage consumes via the context, so they have none.
     """
     if isinstance(result, DownloadResult):
-        ctx.resource = result.resource
+        # Defensive copy: later stages mutate ``ctx.resource`` in place
+        # (e.g. ``FormulaStage`` adds ``dpp_suggestions``), so without a
+        # copy here that mutation would also mutate the ``DownloadResult``
+        # stored in the result chain — making it no longer a true snapshot
+        # of the download stage's output.
+        ctx.resource = dict(result.resource)
         ctx.resource_url = result.resource_url
         ctx.file_hash = result.file_hash
         ctx.content_length = result.content_length
@@ -277,7 +282,10 @@ def _apply_result(ctx: RuntimeContext, result: Any) -> None:
     elif isinstance(result, DatabaseResult):
         ctx.rows_to_copy = result.rows_to_copy
         ctx.copied_count = result.copied_count
-        ctx.existing_info = result.existing_info
+        # Defensive copy — same rationale as ``DownloadResult.resource``.
+        ctx.existing_info = (
+            dict(result.existing_info) if result.existing_info else None
+        )
 
 
 def rehydrate(ctx: RuntimeContext, result: Any) -> None:

--- a/ckanext/datapusher_plus/jobs/runtime_context.py
+++ b/ckanext/datapusher_plus/jobs/runtime_context.py
@@ -108,17 +108,21 @@ def reset_runtime_context(token: contextvars.Token) -> None:
 #
 # Each ``@task`` in ``prefect_flow.py`` returns one of these. They are:
 #
-#   * Small — only data downstream tasks actually need.
+#   * Self-contained — every result nests the result of the stage before
+#     it (``upstream``), so the whole chain of cross-task state is reachable
+#     from any single result. This is what lets ``rehydrate`` (below)
+#     reconstitute the ``RuntimeContext`` from a result alone: a cache hit
+#     or a persisted-result replay skips a task body, so the body's
+#     mutations to the shared context are *not* something a downstream
+#     stage can rely on — the result chain is.
 #   * Typed — so the run graph in the UI is meaningful.
 #   * Serializable — primitives, dicts, lists. No file handles, no loggers,
 #     no subprocess wrappers.
-#   * Cache-friendly — result hashes drive Prefect's caching, so equal
-#     inputs across runs produce equal cached outputs.
 
 
 @dataclass(frozen=True)
 class DownloadResult:
-    """Output of the download task."""
+    """Output of the download task. Root of the result chain."""
 
     resource: Dict[str, Any]
     resource_url: str
@@ -131,30 +135,40 @@ class DownloadResult:
 class ConvertResult:
     """Output of the format-converter task (Excel/ODS/Shapefile/GeoJSON → CSV)."""
 
+    upstream: DownloadResult
     csv_path: str
     # e.g. "xlsx", "shp", or None for pass-through.
     converted_from: Optional[str] = None
-    # Content fingerprint propagated from DownloadResult so downstream
-    # tasks can cache by file identity rather than by tempdir path.
-    file_hash: str = ""  # e.g. "xlsx", "shp", or None for pass-through
+
+    @property
+    def file_hash(self) -> str:
+        """Content fingerprint, carried from the root ``DownloadResult``."""
+        return self.upstream.file_hash
 
 
 @dataclass(frozen=True)
 class ValidateResult:
     """Output of the validation task, including quarantine info."""
 
+    upstream: ConvertResult
     csv_path: str
     rows_after_dedup: int
     quarantined_rows: int = 0
     quarantine_csv_path: Optional[str] = None
-    # Propagated content fingerprint for downstream caching.
-    file_hash: str = ""
+
+    @property
+    def file_hash(self) -> str:
+        """Content fingerprint, carried from the root ``DownloadResult``."""
+        return self.upstream.file_hash
 
 
 @dataclass(frozen=True)
 class AnalyzeResult:
     """Output of the qsv-driven analysis task."""
 
+    upstream: ValidateResult
+    # Working CSV path as analysis left it — what the database COPY reads.
+    csv_path: str
     headers: List[str]
     headers_dicts: List[Dict[str, Any]]
     original_header_dict: Dict[int, str]
@@ -165,23 +179,33 @@ class AnalyzeResult:
     # Count of PII candidate matches — what the PII-review suspend gate
     # thresholds on.
     pii_candidate_count: int = 0
-    # Propagated content fingerprint for downstream caching.
-    file_hash: str = ""
+
+    @property
+    def file_hash(self) -> str:
+        """Content fingerprint, carried from the root ``DownloadResult``."""
+        return self.upstream.file_hash
 
 
 @dataclass(frozen=True)
 class DatabaseResult:
     """Output of the database-load (COPY) task."""
 
+    upstream: AnalyzeResult
     rows_to_copy: int
     copied_count: int
     existing_info: Optional[Dict[str, Any]] = None
+
+    @property
+    def file_hash(self) -> str:
+        """Content fingerprint, carried from the root ``DownloadResult``."""
+        return self.upstream.file_hash
 
 
 @dataclass(frozen=True)
 class IndexingResult:
     """Output of the auto-indexing task."""
 
+    upstream: DatabaseResult
     indexes_created: List[str] = field(default_factory=list)
 
 
@@ -189,6 +213,7 @@ class IndexingResult:
 class FormulaResult:
     """Output of the Jinja2 formula-evaluation task."""
 
+    upstream: IndexingResult
     formula_outputs: Dict[str, Any] = field(default_factory=dict)
     suggestions: Dict[str, Any] = field(default_factory=dict)
 
@@ -197,5 +222,76 @@ class FormulaResult:
 class MetadataResult:
     """Output of the final metadata-update task. Terminal."""
 
+    upstream: FormulaResult
     alias_created: Optional[str] = None
     updated_fields: List[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Rehydration: result chain -> RuntimeContext
+# ---------------------------------------------------------------------------
+#
+# The per-stage result dataclasses above are the *source of truth* for
+# state that crosses a task boundary. ``rehydrate`` walks a nested result
+# chain root-first and writes each layer's fields back onto the
+# ContextVar-bound ``RuntimeContext``, so a stage sees correct ``ctx``
+# state even when an upstream task's body never ran (a Prefect cache hit,
+# or a persisted-result replay on a flow re-run). The stage bodies in
+# ``jobs/stages/*.py`` are reused unmodified — they still read and write
+# ``ctx``; they just no longer *depend* on a previous task body having
+# mutated the shared context in this process.
+
+
+def _apply_result(ctx: RuntimeContext, result: Any) -> None:
+    """Apply one result layer's fields onto ``ctx``.
+
+    Linear ``isinstance`` dispatch keeps every result-to-context mapping
+    visible in one place. Only stages whose output a later stage reads
+    back from ``ctx`` need a branch here; ``IndexingResult`` /
+    ``FormulaResult`` / ``MetadataResult`` carry nothing a downstream
+    stage consumes via the context, so they have none.
+    """
+    if isinstance(result, DownloadResult):
+        ctx.resource = result.resource
+        ctx.resource_url = result.resource_url
+        ctx.file_hash = result.file_hash
+        ctx.content_length = result.content_length
+        ctx.tmp = result.downloaded_path
+    elif isinstance(result, ConvertResult):
+        ctx.tmp = result.csv_path
+    elif isinstance(result, ValidateResult):
+        ctx.tmp = result.csv_path
+        ctx.rows_to_copy = result.rows_after_dedup
+        ctx.quarantined_rows = result.quarantined_rows
+        ctx.quarantine_csv_path = result.quarantine_csv_path or ""
+    elif isinstance(result, AnalyzeResult):
+        ctx.tmp = result.csv_path
+        ctx.headers = list(result.headers)
+        ctx.headers_dicts = list(result.headers_dicts)
+        ctx.original_header_dict = dict(result.original_header_dict)
+        ctx.dataset_stats = dict(result.dataset_stats)
+        ctx.resource_fields_stats = dict(result.resource_fields_stats)
+        ctx.resource_fields_freqs = dict(result.resource_fields_freqs)
+        ctx.pii_found = result.pii_found
+        ctx.pii_candidate_count = result.pii_candidate_count
+    elif isinstance(result, DatabaseResult):
+        ctx.rows_to_copy = result.rows_to_copy
+        ctx.copied_count = result.copied_count
+        ctx.existing_info = result.existing_info
+
+
+def rehydrate(ctx: RuntimeContext, result: Any) -> None:
+    """Reconstitute ``ctx`` from a (possibly nested) result chain.
+
+    Walks ``result.upstream`` to the root, then applies each layer
+    root-first so later stages' values win (e.g. each stage's ``csv_path``
+    overwrites the previous ``ctx.tmp``). A task calls this before running
+    its stage; see the module note above.
+    """
+    chain: List[Any] = []
+    node: Any = result
+    while node is not None:
+        chain.append(node)
+        node = getattr(node, "upstream", None)
+    for node in reversed(chain):
+        _apply_result(ctx, node)

--- a/tests/test_prefect_flow.py
+++ b/tests/test_prefect_flow.py
@@ -515,3 +515,124 @@ def test_flow_marks_skipped_when_a_stage_aborts(job_input, patched_dependencies)
     args, _ = patched_dependencies["mark_completed"].call_args
     assert args[1] == {"skipped": "Analysis"}
     patched_dependencies["mark_errored"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Result-chain rehydration (ProcessingContext retirement)
+# ---------------------------------------------------------------------------
+
+
+def test_rehydrate_reconstitutes_context_from_nested_results():
+    """``rehydrate`` walks a nested result chain and repopulates the
+    RuntimeContext root-first, so a downstream stage sees correct state
+    even though no upstream *task body* ran in this process.
+
+    This is the invariant that lets Prefect skip a cached / persisted
+    task body without leaving the next stage reading empty context.
+    """
+    from ckanext.datapusher_plus.jobs.context import ProcessingContext
+    from ckanext.datapusher_plus.jobs.runtime_context import (
+        AnalyzeResult,
+        ConvertResult,
+        DownloadResult,
+        ValidateResult,
+        rehydrate,
+    )
+
+    download = DownloadResult(
+        resource={"id": "r1", "format": "CSV"},
+        resource_url="http://x/r1.csv",
+        file_hash="abc123",
+        content_length=4096,
+        downloaded_path="/tmp/run/r1.csv",
+    )
+    convert = ConvertResult(upstream=download, csv_path="/tmp/run/r1.converted.csv")
+    validate = ValidateResult(
+        upstream=convert,
+        csv_path="/tmp/run/r1.clean.csv",
+        rows_after_dedup=42,
+        quarantined_rows=3,
+        quarantine_csv_path="/tmp/run/r1.errors.csv",
+    )
+    analyze = AnalyzeResult(
+        upstream=validate,
+        csv_path="/tmp/run/r1.clean.csv",
+        headers=["a", "b"],
+        headers_dicts=[{"id": "a"}, {"id": "b"}],
+        original_header_dict={0: "A", 1: "B"},
+        dataset_stats={"rows": 42},
+        resource_fields_stats={"a": {}},
+        resource_fields_freqs={"a": {}},
+        pii_found=True,
+        pii_candidate_count=2,
+    )
+
+    # A bare context, as _build_runtime_context hands to the first task:
+    # only build-time fields are set, everything else is at its default.
+    ctx = ProcessingContext(task_id="t1", input={})
+
+    rehydrate(ctx, analyze)
+
+    # Root DownloadResult fields.
+    assert ctx.resource == {"id": "r1", "format": "CSV"}
+    assert ctx.resource_url == "http://x/r1.csv"
+    assert ctx.file_hash == "abc123"
+    assert ctx.content_length == 4096
+    # Working path: each layer overwrites it, analysis' value wins.
+    assert ctx.tmp == "/tmp/run/r1.clean.csv"
+    # ValidateResult fields.
+    assert ctx.rows_to_copy == 42
+    assert ctx.quarantined_rows == 3
+    assert ctx.quarantine_csv_path == "/tmp/run/r1.errors.csv"
+    # AnalyzeResult fields.
+    assert ctx.headers == ["a", "b"]
+    assert ctx.headers_dicts == [{"id": "a"}, {"id": "b"}]
+    assert ctx.pii_found is True
+    assert ctx.pii_candidate_count == 2
+    # The file_hash property walks the chain back to the root.
+    assert analyze.file_hash == "abc123"
+    assert validate.file_hash == "abc123"
+    assert convert.file_hash == "abc123"
+
+
+def test_stage_run_rehydrates_context_from_prev():
+    """``_stage_run(stage, prev)`` applies ``prev`` onto the bound context
+    *before* invoking the stage — the cache-hit safety net.
+
+    Simulates a skipped upstream task body (cache hit / persisted-result
+    replay): the only way the stage gets correct state is rehydration.
+    """
+    from ckanext.datapusher_plus.jobs import prefect_flow
+    from ckanext.datapusher_plus.jobs.context import ProcessingContext
+    from ckanext.datapusher_plus.jobs.runtime_context import (
+        DownloadResult,
+        reset_runtime_context,
+        set_runtime_context,
+    )
+
+    prev = DownloadResult(
+        resource={"id": "r1"},
+        resource_url="http://x/r1.csv",
+        file_hash="hash-xyz",
+        content_length=10,
+        downloaded_path="/tmp/run/r1.csv",
+    )
+    # Bare context — as if the download task body was skipped.
+    ctx = ProcessingContext(task_id="t1", input={})
+    seen = {}
+
+    def _stage(c):
+        # The stage must observe a rehydrated context, not the bare one.
+        seen["tmp"] = c.tmp
+        seen["file_hash"] = c.file_hash
+        return c
+
+    stage = mock.MagicMock(side_effect=_stage)
+    token = set_runtime_context(ctx)
+    try:
+        prefect_flow._stage_run(stage, prev)
+    finally:
+        reset_runtime_context(token)
+
+    assert seen["tmp"] == "/tmp/run/r1.csv"
+    assert seen["file_hash"] == "hash-xyz"

--- a/tests/test_prefect_flow.py
+++ b/tests/test_prefect_flow.py
@@ -15,6 +15,7 @@ Docker compose, not pytest in a vacuum.
 
 from __future__ import annotations
 
+import logging
 from unittest import mock
 
 import pytest
@@ -56,6 +57,8 @@ def patched_dependencies():
       * ``datastore_utils.get_resource`` to return a non-datastore resource.
       * ``helpers.add_pending_job`` / ``mark_job_as_*`` to no-op.
       * ``QSVCommand`` constructor + the ``QSV_BIN`` path check.
+      * ``utils.StoringHandler`` → a ``NullHandler`` so the task logger
+        does not write to the ``Logs`` table (no DB bind in unit tests).
       * ``callback_datapusher_hook`` so no HTTP POST goes out.
     """
     patches = [
@@ -109,6 +112,10 @@ def patched_dependencies():
         ),
         mock.patch(
             "ckanext.datapusher_plus.jobs.prefect_flow.dph.mark_job_as_failed_to_post_result"
+        ),
+        mock.patch(
+            "ckanext.datapusher_plus.jobs.prefect_flow.utils.StoringHandler",
+            return_value=logging.NullHandler(),
         ),
         mock.patch(
             "ckanext.datapusher_plus.jobs.prefect_flow.QSVCommand"
@@ -389,6 +396,13 @@ def test_flow_short_circuits_for_datastore_dumps(job_input):
         stack.enter_context(mock.patch.object(prefect_flow.dph, "set_aps_job_id"))
         mark_completed = stack.enter_context(
             mock.patch.object(prefect_flow.dph, "mark_job_as_completed")
+        )
+        stack.enter_context(
+            mock.patch.object(
+                prefect_flow.utils,
+                "StoringHandler",
+                return_value=logging.NullHandler(),
+            )
         )
         stack.enter_context(
             mock.patch.object(prefect_flow.QSVCommand, "__init__", return_value=None)


### PR DESCRIPTION
> **Supersedes #279** — that PR was auto-closed by GitHub when its base branch (`prefect-foundation`, merged via #277) was deleted. Same content, retargeted to `main`. The 3 commits (`430f4c7`, `c8c0e09`, `c22bfd3`) are unchanged.

## What

ProcessingContext-retirement step (the approved plan's **item D**). Makes the per-stage Prefect result dataclasses *self-contained* so the result chain — not a shared mutable ContextVar — is the source of truth for cross-task state.

## Why

The 8 `@task` functions passed `prev` purely as a Prefect DAG edge: every task read and wrote the real cross-task state through one ContextVar-shared `RuntimeContext`, and `prev` was never consumed. That is exactly why result caching had to stay disabled — a cache hit skips the task body, so the ContextVar never receives that stage's mutations and the next stage runs on empty state (`COPY "<table>" () FROM STDIN`).

## Changes

- **`runtime_context.py`** — each result dataclass nests its `upstream` result, so the whole chain of cross-task state is reachable from any single result. `file_hash` becomes a property walking to the root `DownloadResult`; `AnalyzeResult` gains `csv_path` (the database COPY reads `ctx.tmp`). New `rehydrate()` walks the nested chain root-first and applies each layer onto the `RuntimeContext`.
- **`prefect_flow.py`** — `_stage_run(stage, prev=None)` rehydrates the context from `prev` before running the stage, so a stage sees correct `ctx` state even when an upstream task body was skipped (cache hit / persisted-result replay). Each task threads `prev` and builds the nested result. The flow body rehydrates `runtime` from the terminal result so its post-transaction reads derive from the result chain.
- **The 8 stage bodies in `jobs/stages/*.py` are untouched** — they still read/write `ctx`; they just no longer *depend* on a previous task body having mutated the shared context in-process.
- **`caching.py`** — docstring updated: the self-contained-results blocker is cleared; documents the remaining blocker (see below).
- **`tests/test_prefect_flow.py`** — two new tests for `rehydrate()` and the `_stage_run(stage, prev)` cache-hit safety net. Plus a fixture fix (`c8c0e09`): `patched_dependencies` now mocks `StoringHandler` so the flow tests don't try to write to the `Logs` table in a bare unit-test env (turned 7 pre-existing reds green).
- **`.serena/memories/dpp_test_container.md`** (`c22bfd3`) — records the pre-built ckan-dev container for running the unit suite without a local CKAN env.

## Caching is still disabled — on purpose

This PR is the *retirement refactor*, not the caching re-enablement. Tracing the work surfaced a **second** blocker that wasn't previously called out: cached results carry working file paths into a per-flow-run `TemporaryDirectory` that won't exist on a later run. Self-contained results are necessary but not sufficient — caching also needs the working files persisted to stable `result_storage`. That's now documented in `caching.py` as the next step.

## Testing

- `pytest tests/` in the `dpp-test` ckan-dev container: **42/43 pass**. The 1 remaining error (`test_flow_completes_and_marks_job_complete`) is a separate pre-existing import-time bootstrap issue, flagged in `HANDOFF.md` and unrelated to this PR.
- Integration CI (`ci.yml`) will now run on this PR (base = `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)