### PR TITLE
feat(prefect): DPP_PREFECT_WORKER sentinel for the bootstrap

### DIFF
--- a/ckanext/datapusher_plus/cli.py
+++ b/ckanext/datapusher_plus/cli.py
@@ -214,6 +214,13 @@ def prefect_deploy(work_pool: str | None):
         # custom flow + their own prefect.yaml.
         image=None,
         push=False,
+        # Sentinel read by ``prefect_flow._bootstrap_ckan_app_context`` so
+        # it can tell a real worker subprocess apart from pytest / ad-hoc
+        # imports / tooling, and only call ``make_app()`` for the former.
+        # Prefect merges these vars into the worker subprocess's env at
+        # flow-run start; ``CKAN_INI`` continues to come from the worker's
+        # own environment (operator-set per deployment).
+        job_variables={"env": {"DPP_PREFECT_WORKER": "1"}},
     )
     click.echo(f"Deployed to work-pool '{pool}': {deployment_id}")
 

--- a/ckanext/datapusher_plus/cli.py
+++ b/ckanext/datapusher_plus/cli.py
@@ -223,6 +223,17 @@ def prefect_deploy(work_pool: str | None):
         job_variables={"env": {"DPP_PREFECT_WORKER": "1"}},
     )
     click.echo(f"Deployed to work-pool '{pool}': {deployment_id}")
+    # Surface the sentinel-env-var contract for operators. ``prefect-deploy``
+    # injects it for them, but anyone who later moves to a hand-rolled
+    # ``prefect.yaml`` needs to replicate it -- without the sentinel the
+    # worker's import-time bootstrap no-ops and the first ``tk.get_action``
+    # call later crashes with a stale-action-registry error.
+    click.echo(
+        "  Worker subprocess env will receive DPP_PREFECT_WORKER=1 (sentinel "
+        "for _bootstrap_ckan_app_context). If you deploy via your own "
+        "prefect.yaml instead of this command, replicate it under "
+        "job_variables.env -- the bootstrap is a no-op without it."
+    )
 
 
 @datapusher_plus.command(name="migrate-from-rq")

--- a/ckanext/datapusher_plus/jobs/prefect_flow.py
+++ b/ckanext/datapusher_plus/jobs/prefect_flow.py
@@ -81,7 +81,12 @@ def _bootstrap_ckan_app_context() -> None:
     2. ``ckan.common.config`` is already populated — imported from a
        ``ckan`` CLI command (e.g. ``datapusher_plus prefect-deploy``),
        whose ``CtxObject`` already ran ``make_app`` — no-op;
-    3. otherwise we are a fresh interpreter that *must* bootstrap. A
+    3. ``DPP_PREFECT_WORKER`` sentinel is unset — we are not inside a
+       genuine Prefect worker subprocess (pytest, ad-hoc imports,
+       tooling that loads this plugin) — no-op. ``prefect-deploy`` sets
+       ``DPP_PREFECT_WORKER=1`` on the deployment's job-variables env so
+       every worker subprocess inherits it;
+    4. otherwise we are a fresh worker subprocess that *must* bootstrap. A
        missing/unreadable ``CKAN_INI`` here is fatal: continuing would
        import ``config.py`` against an empty ``tk.config`` and silently
        run the whole pipeline on hardcoded defaults (wrong datastore
@@ -115,9 +120,17 @@ def _bootstrap_ckan_app_context() -> None:
 
     log = logging.getLogger(__name__)
 
-    # 3. Fresh interpreter — a Prefect worker subprocess. CKAN_INI is
-    #    mandatory here; a silent no-op would run the pipeline on stock
-    #    defaults.
+    # 3. ``DPP_PREFECT_WORKER`` sentinel: ``prefect-deploy`` sets this on
+    #    the deployment's job-variables env, so every worker subprocess
+    #    Prefect spawns for this deployment inherits ``DPP_PREFECT_WORKER=1``.
+    #    Anywhere else (pytest, ad-hoc imports, tooling) it stays unset
+    #    and the bootstrap is a no-op — guarding against an expensive /
+    #    fragile ``make_app()`` call against an unconfigured CKAN env.
+    if os.environ.get("DPP_PREFECT_WORKER") != "1":
+        return
+
+    # 4. Fresh worker interpreter. CKAN_INI is mandatory here; a silent
+    #    no-op would run the pipeline on stock defaults.
     ini = os.environ.get("CKAN_INI")
     if not ini or not os.path.exists(ini):
         raise RuntimeError(

--- a/tests/test_prefect_flow.py
+++ b/tests/test_prefect_flow.py
@@ -669,14 +669,22 @@ def test_bootstrap_noops_when_worker_sentinel_unset():
     returns silently without calling ``make_app``. This is the guard
     that lets pytest import ``prefect_flow`` without bringing up a full
     CKAN stack at module import.
+
+    Forces guards #1 (Flask app context) and #2 (``ckan.common.config``
+    populated) to NOT fire so the assertion exercises guard #3 even if
+    an earlier test (or a future conftest) leaves either of the other
+    guards primed.
     """
     import os
+    from ckan.common import config as ckan_config
     from ckanext.datapusher_plus.jobs.prefect_flow import (
         _bootstrap_ckan_app_context,
     )
 
     with mock.patch.dict(
         os.environ, {"DPP_PREFECT_WORKER": "0"}, clear=False
+    ), mock.patch("flask.has_app_context", return_value=False), mock.patch.object(
+        ckan_config, "get", return_value=None
     ), mock.patch("ckan.config.middleware.make_app") as mk_make_app:
         _bootstrap_ckan_app_context()
     mk_make_app.assert_not_called()

--- a/tests/test_prefect_flow.py
+++ b/tests/test_prefect_flow.py
@@ -650,3 +650,72 @@ def test_stage_run_rehydrates_context_from_prev():
 
     assert seen["tmp"] == "/tmp/run/r1.csv"
     assert seen["file_hash"] == "hash-xyz"
+
+
+
+# ---------------------------------------------------------------------------
+# _bootstrap_ckan_app_context — no-op guards
+# ---------------------------------------------------------------------------
+#
+# Covers the roborev follow-up "No dedicated unit test for
+# `_bootstrap_ckan_app_context`'s no-op guards" and the new
+# `DPP_PREFECT_WORKER` sentinel guard — the latter is what lets pytest
+# (and the CKAN web app, ad-hoc tooling, etc.) import `prefect_flow`
+# safely, since the bootstrap no-ops outside a genuine worker subprocess.
+
+
+def test_bootstrap_noops_when_worker_sentinel_unset():
+    """No ``DPP_PREFECT_WORKER=1`` → ``_bootstrap_ckan_app_context``
+    returns silently without calling ``make_app``. This is the guard
+    that lets pytest import ``prefect_flow`` without bringing up a full
+    CKAN stack at module import.
+    """
+    import os
+    from ckanext.datapusher_plus.jobs.prefect_flow import (
+        _bootstrap_ckan_app_context,
+    )
+
+    with mock.patch.dict(
+        os.environ, {"DPP_PREFECT_WORKER": "0"}, clear=False
+    ), mock.patch("ckan.config.middleware.make_app") as mk_make_app:
+        _bootstrap_ckan_app_context()
+    mk_make_app.assert_not_called()
+
+
+def test_bootstrap_noops_when_app_context_present():
+    """Existing guard #1: a Flask app context is already pushed (the
+    CKAN web process imported the plugin) → bootstrap is a no-op even
+    when the worker sentinel is set.
+    """
+    import os
+    from ckanext.datapusher_plus.jobs.prefect_flow import (
+        _bootstrap_ckan_app_context,
+    )
+
+    with mock.patch.dict(
+        os.environ, {"DPP_PREFECT_WORKER": "1"}, clear=False
+    ), mock.patch("flask.has_app_context", return_value=True), mock.patch(
+        "ckan.config.middleware.make_app"
+    ) as mk_make_app:
+        _bootstrap_ckan_app_context()
+    mk_make_app.assert_not_called()
+
+
+def test_bootstrap_noops_when_ckan_config_populated():
+    """Existing guard #2: ``ckan.common.config`` is already populated
+    (a ``ckan`` CLI command already ran ``make_app``) → bootstrap is a
+    no-op even when the worker sentinel is set.
+    """
+    import os
+    from ckan.common import config as ckan_config
+    from ckanext.datapusher_plus.jobs.prefect_flow import (
+        _bootstrap_ckan_app_context,
+    )
+
+    with mock.patch.dict(
+        os.environ, {"DPP_PREFECT_WORKER": "1"}, clear=False
+    ), mock.patch("flask.has_app_context", return_value=False), mock.patch.object(
+        ckan_config, "get", return_value="http://example.test"
+    ), mock.patch("ckan.config.middleware.make_app") as mk_make_app:
+        _bootstrap_ckan_app_context()
+    mk_make_app.assert_not_called()


### PR DESCRIPTION
> **Stacked on #280.** Base is \`prefect-context-retirement\` so the diff is just this one commit. When #280 merges to \`main\`, **retarget this PR to \`main\` *before* anyone deletes \`prefect-context-retirement\`** — auto-close on base-branch-delete is irreversible (see #279's fate).

## What

Adds a `DPP_PREFECT_WORKER=1` sentinel env var so `_bootstrap_ckan_app_context()` only fires inside a real Prefect worker subprocess. Anywhere else (pytest, ad-hoc plugin imports, tooling) the bootstrap is a no-op — `prefect-deploy` sets the sentinel on the deployment's `job_variables.env` so genuine worker subprocesses inherit it.

This was a reviewer suggestion (see HANDOFF.md / earlier roborev notes) that had been deferred. Picking it up because it has an outsized payoff for its size.

## Why

The bootstrap runs at module import. Without a sentinel, *any* path that imports `prefect_flow` (a pytest test using `mock.patch("...prefect_flow.X")`, a CKAN admin command that loads the DP+ plugin, an IDE indexing the codebase) triggers `make_app(load_config(CKAN_INI))` — which needs a full CKAN env (`SECRET_KEY`, Solr connectivity, ...). In unit tests this surfaced as `test_flow_completes_and_marks_job_complete` erroring on the first `mock.patch(...prefect_flow.DownloadStage)` call.

## Changes

- **`prefect_flow.py` — `_bootstrap_ckan_app_context`**: new guard #3 after the existing app-context / `ckan.common.config`-populated guards. If `DPP_PREFECT_WORKER != "1"`, return. The previous "fresh interpreter" branch (now numbered 4) is unchanged. Docstring renumbered.
- **`cli.py` — `prefect_deploy`**: adds `job_variables={"env": {"DPP_PREFECT_WORKER": "1"}}` to the `.deploy(...)` call. Prefect merges this into each worker subprocess's env. `CKAN_INI` continues to come from the worker's own environment (operator-set per deployment).
- **`tests/test_prefect_flow.py`**: three guards-as-documented unit tests — one for the new sentinel guard, two for the pre-existing guards (app context, ckan config). Addresses the roborev follow-up "No dedicated unit test for `_bootstrap_ckan_app_context`'s no-op guards" at the same time.

## Verification (in the `dpp-test` ckan-dev container)

| | Before | After |
|---|---|---|
| `test_prefect_flow.py` | 12 passed | **15 passed** |
| Full unit suite (`tests/ --ignore=tests/integration`) | 42 passed, 1 error | **46 passed, 0 errors** |

The 1 previously pre-existing error (`test_flow_completes_and_marks_job_complete`) is now green: with `DPP_PREFECT_WORKER` unset in the pytest env, the bootstrap no-ops at import time, so the fixture's `mock.patch(...)` calls resolve cleanly.

Integration CI (the 7-file `ci.yml` `quick`-dir matrix) will also run on this PR and should continue to pass — the worker subprocess that runs each test file's flow will have `DPP_PREFECT_WORKER=1` from the deployment's job_variables.

## Operator note

If you run a worker without going through `ckan datapusher_plus prefect-deploy` (e.g., a hand-rolled `prefect.yaml`), set `DPP_PREFECT_WORKER=1` in the worker process's environment yourself — or your flow runs will silently no-op the bootstrap and fail on the first `tk.get_action(...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)