### PR TITLE
chore(deps): tighten Prefect pin to >=3.7,<3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ fiona==1.10.1
 pandas==2.2.3
 shapely==2.1.0
 pyproj>=3.7.1
-prefect>=3.0,<4
+prefect>=3.7,<3.8


### PR DESCRIPTION
## Summary
- Tightens the Prefect dependency in `requirements.txt` from `>=3.0,<4` to `>=3.7,<3.8`.
- 3.7.0 is the current PyPI latest and the version every recent green CI run resolved (most recently run `25949340122` on PR #281 at `3eda2f7`).
- Cap at `<3.8` so we don't silently roll into a new minor with cross-version `flow.from_source` behavior changes (the original roborev #2098 concern).
- In-line 3.7.x patch upgrades remain allowed for bugfixes.

Addresses one of the items on tracking issue #282 (Prefect 3 migration — deferred follow-ups).

## Test plan
- [ ] `ci.yml` (DataPusher+ Integration CI) — 7-file quick-dir check resolves and installs `prefect>=3.7,<3.8`, brings up the stack, all 7 expected outcomes match.
- [ ] (Optional) `main.yml` (Automated DataPusher+ Testing Run) — full 22-file matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)