### PR TITLE
refactor(prefect): runtime-resolve flow-timeout + download retries

### DIFF
--- a/ckanext/datapusher_plus/jobs/prefect_flow.py
+++ b/ckanext/datapusher_plus/jobs/prefect_flow.py
@@ -263,22 +263,32 @@ def _resolve_int(env_name: str, config_key: str, default: int) -> int:
     return default
 
 
-# These are read once at module import and baked into the ``@flow`` /
-# ``@task`` decorators below. The default ``process`` work pool spawns a
-# fresh Python interpreter per flow run, so it re-imports this module —
-# and re-reads these values — every run; env-var / ckan.ini changes take
-# effect immediately there. Operators on a work-pool type that reuses a
-# long-lived interpreter must restart their workers for a change to
-# these three knobs to take effect.
+# Module-import-time constants:
+#
+# ``_FLOW_TIMEOUT_SECONDS`` is read once at module import and baked into
+# the ``@flow`` decorator below as Prefect's hard-stop ceiling. The
+# default ``process`` work pool spawns a fresh Python interpreter per
+# flow run, so it re-imports this module — and re-reads this value —
+# every run; env-var / ckan.ini changes take effect immediately there.
+# On a work-pool type that reuses a long-lived interpreter, operators
+# need a worker restart for the hard ceiling to change, but the
+# *runtime* deadline check inside ``datapusher_plus_flow`` re-resolves
+# the same knob every run — so a shorter runtime value takes effect
+# without a restart even on those pools.
+#
+# ``_TASK_RETRY_DATABASE`` is also import-time. Asymmetric with
+# ``download_task`` (whose retries are resolved per-run inside the flow
+# body via ``with_options``) because the database task carries an
+# ``on_rollback`` hook that drops the partial datastore table on
+# transactional failure, and ``Task.with_options`` in Prefect 3.x does
+# *not* preserve ``on_rollback_hooks`` — it preserves on_completion /
+# on_failure / on_running, but not rollback. Re-deriving the task at
+# runtime would silently break the rollback contract, so we accept the
+# import-time read here and document the limitation.
 _FLOW_TIMEOUT_SECONDS = _resolve_int(
     "DATAPUSHER_PLUS_FLOW_TIMEOUT_SECONDS",
     "ckanext.datapusher_plus.flow_timeout",
     7200,
-)
-_TASK_RETRY_DOWNLOAD = _resolve_int(
-    "DATAPUSHER_PLUS_DOWNLOAD_RETRIES",
-    "ckanext.datapusher_plus.download_retries",
-    3,
 )
 _TASK_RETRY_DATABASE = _resolve_int(
     "DATAPUSHER_PLUS_DATABASE_RETRIES",
@@ -438,7 +448,13 @@ def _retry_if_transient(task, task_run, state) -> bool:
 
 @task(
     name="download",
-    retries=_TASK_RETRY_DOWNLOAD,
+    # ``retries`` is set per-run via ``task.with_options(retries=…)``
+    # at the call site in ``datapusher_plus_flow`` so the count is
+    # resolved from env / ckan.ini at run time (and so picks up changes
+    # without a worker restart on interpreter-reusing work pools).
+    # Safe to do here (unlike ``database_task``) because download has
+    # no ``on_rollback`` hook — there's nothing for Prefect's
+    # ``with_options`` strip-and-recopy to lose.
     retry_delay_seconds=[10, 60, 300],
     retry_condition_fn=_retry_if_transient,
     tags=["datapusher-plus", "io-bound"],
@@ -546,6 +562,10 @@ def analyze_task(prev: ValidateResult) -> AnalyzeResult:
 
 @task(
     name="database-load",
+    # Import-time read (see the comment block near the constants
+    # definitions): a runtime ``with_options(retries=…)`` would strip
+    # the ``on_rollback`` hook registered below, silently breaking the
+    # datastore-cleanup contract on transactional failure.
     retries=_TASK_RETRY_DATABASE,
     retry_delay_seconds=30,
     retry_condition_fn=_retry_if_transient,
@@ -994,6 +1014,44 @@ def datapusher_plus_flow(job_input: JobInput) -> Optional[str]:
         dph.mark_job_as_errored(job_id, str(e))
         raise
 
+    # Runtime-resolved tunables. Reading these here (not at module
+    # import) means env / ckan.ini changes take effect on the very next
+    # flow run, even on work-pool types that reuse a long-lived
+    # interpreter. On the default ``process`` work pool the module is
+    # re-imported per run anyway, so this is equivalent to the
+    # import-time read there. ``database_retries`` is *not* runtime-
+    # resolved — see the comment block near the constants definitions
+    # at the top of the module for why.
+    download_retries = _resolve_int(
+        "DATAPUSHER_PLUS_DOWNLOAD_RETRIES",
+        "ckanext.datapusher_plus.download_retries",
+        3,
+    )
+    flow_timeout_seconds = _resolve_int(
+        "DATAPUSHER_PLUS_FLOW_TIMEOUT_SECONDS",
+        "ckanext.datapusher_plus.flow_timeout",
+        7200,
+    )
+    flow_start = time.monotonic()
+
+    def _check_deadline():
+        """Raise if the runtime-resolved flow deadline has been exceeded.
+
+        Soft enforcement: only checked between stages, so a stage hung
+        mid-execution will not be aborted by this — the ``@flow``
+        decorator's import-time ``timeout_seconds`` ceiling is the hard
+        backstop for that case. The point of this softer check is to
+        honour a *runtime-resolved* deadline so env / ckan.ini changes
+        take effect without a worker restart on interpreter-reusing
+        work pools.
+        """
+        elapsed = time.monotonic() - flow_start
+        if elapsed > flow_timeout_seconds:
+            raise utils.JobError(
+                f"Flow exceeded configured timeout of "
+                f"{flow_timeout_seconds}s (elapsed: {elapsed:.0f}s)"
+            )
+
     # Announce running state to CKAN.
     result_url = job_input.input.get("result_url")
     if result_url:
@@ -1022,11 +1080,17 @@ def datapusher_plus_flow(job_input: JobInput) -> Optional[str]:
                 dph.mark_job_as_completed(job_id, {"skipped": "datastore-managed"})
                 return None
 
-            # Read-only / non-destructive stages.
-            dl = download_task(job_input)
+            # Read-only / non-destructive stages. ``download_task`` gets
+            # its retry count resolved per-run (see the comment block
+            # above the constants near the top of the module).
+            dl = download_task.with_options(retries=download_retries)(
+                job_input
+            )
+            _check_deadline()
             cv = format_convert_task(dl)
             vl = validate_task(cv)
             an = analyze_task(vl)
+            _check_deadline()
 
             # Human-in-the-loop gate. When PII screening flags more
             # fields than ``pii_review_threshold``, the flow suspends
@@ -1043,6 +1107,7 @@ def datapusher_plus_flow(job_input: JobInput) -> Optional[str]:
             # drop or flagged for review when the table pre-existed).
             with transaction():
                 db = database_task(an)
+                _check_deadline()
                 idx = indexing_task(db)
                 fm = formula_task(idx)
                 md = metadata_task(fm)

--- a/tests/test_prefect_flow.py
+++ b/tests/test_prefect_flow.py
@@ -727,3 +727,70 @@ def test_bootstrap_noops_when_ckan_config_populated():
     ), mock.patch("ckan.config.middleware.make_app") as mk_make_app:
         _bootstrap_ckan_app_context()
     mk_make_app.assert_not_called()
+
+
+
+def test_flow_resolves_retry_counts_per_run(
+    job_input, patched_dependencies, monkeypatch
+):
+    """``download_task``'s retry count is resolved from env at flow
+    start (via ``task.with_options(retries=…)``) so a change picks up
+    immediately on interpreter-reusing work pools. The default
+    ``process`` worker re-imports per run anyway, but this test
+    exercises the resolution path itself.
+
+    ``database_task`` is *not* covered here: ``with_options`` strips
+    its ``on_rollback`` hook in Prefect 3.x, so it stays import-time —
+    see the comment block near the constants definitions in
+    ``prefect_flow.py``.
+    """
+    from ckanext.datapusher_plus.jobs import prefect_flow
+
+    monkeypatch.setenv("DATAPUSHER_PLUS_DOWNLOAD_RETRIES", "7")
+
+    # Spy on ``with_options``; return the original task so the stage
+    # body still runs (and ``patched_dependencies`` keeps every stage
+    # as a no-op).
+    download_with_options = mock.MagicMock(
+        return_value=prefect_flow.download_task
+    )
+    monkeypatch.setattr(
+        prefect_flow.download_task, "with_options", download_with_options
+    )
+
+    result = prefect_flow.datapusher_plus_flow(job_input)
+
+    assert result is None
+    download_with_options.assert_called_once_with(retries=7)
+
+
+def test_flow_aborts_when_soft_deadline_exceeded(
+    job_input, patched_dependencies, monkeypatch
+):
+    """The runtime-resolved soft deadline raises ``JobError`` (and the
+    flow records ``mark_job_as_errored``) when elapsed time at the
+    first between-stage check exceeds ``flow_timeout_seconds``. The
+    ``@flow`` decorator's hard ceiling is unaffected — this test only
+    exercises the body-level check.
+
+    Uses a deadline of ``0`` rather than patching ``time.monotonic``:
+    the latter is also called by Prefect's flow infrastructure
+    (run-context bookkeeping) and exhausts a small ``iter`` of fake
+    values before the flow body runs. With a 0 deadline, any positive
+    elapsed time at the check triggers, which is what we want.
+    """
+    from ckanext.datapusher_plus.jobs import prefect_flow
+
+    monkeypatch.setenv("DATAPUSHER_PLUS_FLOW_TIMEOUT_SECONDS", "0")
+
+    with pytest.raises(Exception):
+        # JobError propagates as a real exception out of the flow when
+        # called in-process (no Prefect server to wrap it into a state).
+        prefect_flow.datapusher_plus_flow(job_input)
+
+    # The flow's except-block marked the job as errored with the
+    # deadline-exceeded message before raising.
+    mark_errored = patched_dependencies["mark_errored"]
+    assert mark_errored.called
+    err_msg = mark_errored.call_args[0][1]
+    assert "Flow exceeded configured timeout of 0s" in err_msg


### PR DESCRIPTION
## Summary
Addresses the "import-time constants" follow-up on #282. Two of the three knobs that were baked into the `@flow` / `@task` decorators at module import are now re-resolved per flow run, so env / `ckan.ini` changes take effect on the very next run — even on work-pool types that reuse a long-lived interpreter. (The default `process` worker re-imports per run anyway, so behavior there is unchanged.)

### What moved to runtime resolution

- **Download retries** (`DATAPUSHER_PLUS_DOWNLOAD_RETRIES` / `ckanext.datapusher_plus.download_retries`): the flow body now applies the count via `download_task.with_options(retries=download_retries)(...)` instead of the `@task(retries=…)` decorator.
- **Flow timeout** (`DATAPUSHER_PLUS_FLOW_TIMEOUT_SECONDS` / `ckanext.datapusher_plus.flow_timeout`): the `@flow` decorator's `timeout_seconds` stays as Prefect's hard-stop ceiling (the only thing that can kill a stage hung mid-execution). Added a soft `_check_deadline()` between stages that uses a runtime-resolved value. A *shorter* deadline takes effect immediately on any worker type; raising it above the import-time ceiling still requires a restart on interpreter-reusing pools.

### What stayed import-time, and why

- **Database retries** (`_TASK_RETRY_DATABASE`): `Task.with_options()` in Prefect 3.x preserves `on_completion` / `on_failure` / `on_running` hooks but **does not preserve `on_rollback_hooks`**. `database_task` carries the rollback hook that drops the partial datastore table on transactional failure (`@database_task.on_rollback`). Silently breaking that contract for a per-run config refresh would be a net loss. Both the constants block and the `@task` decorator comment now spell this out.

Verified empirically in `dpp-test`:
```python
>>> t = task(lambda: None); t.on_rollback(my_hook)
>>> t.with_options(retries=5).on_rollback_hooks
[]
```

### Tests
Two new cases in `tests/test_prefect_flow.py`:
1. `test_flow_resolves_retry_counts_per_run` — spies on `download_task.with_options` and asserts it's called with the env-resolved retry count.
2. `test_flow_aborts_when_soft_deadline_exceeded` — sets the deadline env var to `"0"` and asserts `mark_job_as_errored` fires with the deadline message before the flow propagates `JobError`.

Verified locally in the `dpp-test` ckan-dev container: **52/52 unit tests pass** (50 prior + 2 new).

## Test plan
- [ ] `ci.yml` (DataPusher+ Integration CI) — 7-file quick-dir matrix still passes; in particular the rollback path on `database_task` still fires (regression test for the asymmetry that made me revert the database-retries change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)