### PR TITLE
feat(prefect): re-enable content caching with stable file persistence

### DIFF
--- a/ckanext/datapusher_plus/jobs/caching.py
+++ b/ckanext/datapusher_plus/jobs/caching.py
@@ -3,28 +3,31 @@
 Result-persistence and cache-key configuration for the Prefect flow.
 
 **Result persistence** (``persist_result=True`` + ``result_storage=...``)
-is active: every task output is checkpointed so operators can open a
-task's output from the Prefect UI to debug bad data.
+is active on every task: outputs are checkpointed so operators can
+open a task's output from the Prefect UI to debug bad data.
 
-**Content-based caching is currently DISABLED** — ``prefect_flow.py``
-does not pass ``cache_policy=`` to any task. The cache-key functions
-and policies below are kept for when it can be safely re-enabled.
+**Content-based caching is enabled** on the read-only stages
+(``download_task``, ``format_convert_task``, ``validate_task``,
+``analyze_task``); the cache-key functions below build keys from the
+content fingerprint propagated through the result chain, so identical
+content across runs hits the cache and skips the qsv subprocess. The
+mutating stages (``database_task``, ``indexing_task``,
+``formula_task``, ``metadata_task``) intentionally do NOT cache —
+caching the result would skip the side effect.
 
-The original blocker is now cleared: each per-stage result dataclass is
-self-contained (it nests its ``upstream`` result), and every task
-``rehydrate``-s the ``RuntimeContext`` from its input result before
-running its stage. So a cache *hit* — which skips the task body — no
-longer leaves a downstream stage reading empty state (the
-``COPY "<table>" () FROM STDIN`` failure that first forced caching off).
+The original blocker (each per-stage result dataclass needs to be
+self-contained so a cache *hit* — which skips the task body —
+doesn't leave a downstream stage reading empty state) was cleared in
+PR #280: every task ``rehydrate``-s the ``RuntimeContext`` from its
+input result before running its stage.
 
-What still blocks re-enabling it: the result dataclasses carry working
-*file paths* (``downloaded_path``, ``csv_path``) that point into a
-per-flow-run ``TemporaryDirectory``. A cached result from an earlier
-run references a tempdir that no longer exists, so the consuming stage
-would fail on a missing file. Safely re-enabling content caching needs
-the working files persisted to stable ``result_storage`` (and rehydra-
-tion to stage them back into the current tempdir) — the next step of
-the ProcessingContext-retirement work.
+The second blocker (cached results carried tempdir paths that didn't
+survive to the next run) was cleared in PR #286: each file-carrying
+result dataclass now stores a stable ``*_path_key`` alongside its
+local path; ``file_persistence.persist_file`` writes the working file
+to the result-storage block at task completion, and the rehydration
+path (``runtime_context._resolve_or_restore``) fetches it back into
+the current run's tempdir on a cross-run cache hit.
 """
 
 from __future__ import annotations
@@ -167,15 +170,27 @@ def content_cache_key(context, parameters) -> Optional[str]:
 # ``cache_policies`` module isn't available (older Prefect 3.x or
 # tooling contexts).
 
+# We deliberately do NOT compose with ``TASK_SOURCE`` here. A naive
+# ``CacheKeyFnPolicy(cache_key_fn=key_fn) + TASK_SOURCE`` has a
+# correctness hazard: Prefect 3's ``CompoundCachePolicy.compute_key``
+# drops ``None`` contributions and hashes the rest, so when ``key_fn``
+# returns ``None`` (no file_hash propagated yet, or operator passed
+# ``ignore_hash=True``) the compound key collapses to just the
+# TASK_SOURCE hash — identical for every invocation of that task with
+# the same task source, regardless of parameters. Two unrelated runs
+# with no content key would hit each other's cache. Verified
+# empirically against Prefect 3.7.
+#
+# Without TASK_SOURCE, a DP+ upgrade that changes a task body does NOT
+# automatically invalidate older cached output. Operators relying on
+# fresh output after an upgrade should either delete the result-storage
+# Block contents or shorten ``DATAPUSHER_PLUS_CACHE_TTL_HOURS``. The
+# default 24h expiration bounds the staleness window.
 try:
-    from prefect.cache_policies import CacheKeyFnPolicy, TASK_SOURCE
+    from prefect.cache_policies import CacheKeyFnPolicy
 
-    DOWNLOAD_CACHE_POLICY = (
-        CacheKeyFnPolicy(cache_key_fn=download_cache_key) + TASK_SOURCE
-    )
-    CONTENT_CACHE_POLICY = (
-        CacheKeyFnPolicy(cache_key_fn=content_cache_key) + TASK_SOURCE
-    )
+    DOWNLOAD_CACHE_POLICY = CacheKeyFnPolicy(cache_key_fn=download_cache_key)
+    CONTENT_CACHE_POLICY = CacheKeyFnPolicy(cache_key_fn=content_cache_key)
 except ImportError as e:  # pragma: no cover - older Prefect 3.x
     # Only a missing module is an expected fallback. A narrower catch
     # than bare ``Exception`` so a real bug (e.g. a bad CacheKeyFnPolicy

--- a/ckanext/datapusher_plus/jobs/file_persistence.py
+++ b/ckanext/datapusher_plus/jobs/file_persistence.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""
+Persist task working files to the Prefect result-storage block so
+cached task results stay valid across runs.
+
+The result dataclasses in ``runtime_context`` carry working file paths
+(``downloaded_path``, ``csv_path``, ``quarantine_csv_path``) that point
+into a per-run ``TemporaryDirectory``. When a downstream stage hits a
+*cached* result from an earlier run, those paths reference a tempdir
+that no longer exists — so the consuming stage cannot read the file.
+
+This module's two helpers solve that:
+
+* ``persist_file`` writes a local file to the configured result-storage
+  block under a stable, content-hash-keyed name at task completion.
+* ``restore_file`` fetches that file back into the current run's
+  tempdir when ``_apply_result`` rehydrates a cached result whose
+  recorded tempdir path no longer exists.
+
+Both helpers degrade gracefully: when the storage block isn't
+available (no Prefect server, block not yet registered, tooling
+context), ``persist_file`` returns ``None`` and ``restore_file``
+returns ``False``. Callers treat that as "no persistence happened"
+and continue with the in-tempdir copy — same behaviour as before
+caching was re-enabled.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from ckanext.datapusher_plus.jobs.blocks import load_result_storage_block
+
+log = logging.getLogger(__name__)
+
+
+def persist_file(local_path: str, key: str) -> Optional[str]:
+    """Write a local file's contents to the result-storage block.
+
+    Args:
+        local_path: Filesystem path to the file to persist.
+        key: Stable identifier to store it under (typically derived
+            from the content hash + stage name).
+
+    Returns:
+        ``key`` on success, or ``None`` if the block is unavailable
+        or the write failed. Callers should treat ``None`` as "no
+        persistence recorded" — the result dataclass leaves its
+        ``*_path_key`` field at ``None`` and cross-run rehydration
+        falls back to the in-tempdir copy (which works for same-run
+        chains, just not cache hits).
+    """
+    block = load_result_storage_block()
+    if block is None:
+        return None
+    try:
+        with open(local_path, "rb") as fh:
+            data = fh.read()
+        block.write_path(key, data)
+        log.debug("Persisted file %s to result storage as %s", local_path, key)
+        return key
+    except FileNotFoundError:
+        log.warning("Could not persist file %s: not found", local_path)
+        return None
+    except Exception as e:
+        # ``write_path`` can fail on a permission / disk / network
+        # error. Log and degrade — the caller still gets a working
+        # result for the same-run case; only cross-run cache hits
+        # lose their persisted file.
+        log.warning("Could not persist file %s as %s: %s", local_path, key, e)
+        return None
+
+
+def restore_file(key: str, dest_path: str) -> bool:
+    """Fetch a previously-persisted file from result storage.
+
+    Args:
+        key: Storage key returned by an earlier ``persist_file`` call.
+        dest_path: Local filesystem path to write the contents to.
+            Parent directory must already exist (typically the current
+            run's tempdir, which always exists at rehydration time).
+
+    Returns:
+        ``True`` if the file was restored, ``False`` if the storage
+        block is unavailable, the key is missing, or the write failed.
+        Callers treat ``False`` as "rehydration skipped" — the cached
+        result's path field is left as-is and the downstream stage
+        will fail with a clear ``FileNotFoundError`` rather than
+        appearing to succeed on stale data.
+    """
+    block = load_result_storage_block()
+    if block is None:
+        return False
+    try:
+        data = block.read_path(key)
+        with open(dest_path, "wb") as fh:
+            fh.write(data)
+        log.debug("Restored file %s from result storage key %s", dest_path, key)
+        return True
+    except Exception as e:
+        # ``read_path`` raises a generic exception for "not found" in
+        # most Prefect block backends. Treat any failure here as
+        # "not restorable" — the caller falls back to letting the
+        # downstream stage surface a clear missing-file error.
+        log.debug("Could not restore file %s from %s: %s", dest_path, key, e)
+        return False

--- a/ckanext/datapusher_plus/jobs/prefect_flow.py
+++ b/ckanext/datapusher_plus/jobs/prefect_flow.py
@@ -185,7 +185,13 @@ import ckanext.datapusher_plus.job_exceptions as job_exceptions
 import ckanext.datapusher_plus.prefect_client as prefect_client
 import ckanext.datapusher_plus.utils as utils
 from ckanext.datapusher_plus.jobs import artifacts, events, quarantine
-from ckanext.datapusher_plus.jobs.caching import DEFAULT_RESULT_STORAGE
+from ckanext.datapusher_plus.jobs.caching import (
+    CONTENT_CACHE_POLICY,
+    DEFAULT_CACHE_EXPIRATION,
+    DEFAULT_RESULT_STORAGE,
+    DOWNLOAD_CACHE_POLICY,
+)
+from ckanext.datapusher_plus.jobs.file_persistence import persist_file
 from ckanext.datapusher_plus.jobs.context import ProcessingContext
 from ckanext.datapusher_plus.jobs.runtime_context import (
     AnalyzeResult,
@@ -261,6 +267,33 @@ def _resolve_int(env_name: str, config_key: str, default: int) -> int:
         # ``prefect worker`` process) — fall through to the default.
         pass
     return default
+
+
+
+def _persist_stage_file(
+    local_path: Optional[str], file_hash: Optional[str], stage: str, slot: str
+) -> Optional[str]:
+    """Persist a stage's working file to result storage, return the key.
+
+    Returns ``None`` (and records nothing on the result dataclass) when:
+
+    * ``local_path`` is empty / falsy — nothing to persist;
+    * ``file_hash`` is empty — without a content hash we cannot build a
+      stable cross-run key;
+    * the result-storage block is unavailable or the write failed —
+      ``persist_file`` already logs the reason.
+
+    The key layout — ``dpp:files:{file_hash}:{stage}:{slot}`` — namespaces
+    by content fingerprint, then stage, then slot (a stage with multiple
+    file outputs uses different slots, e.g. ``ValidateResult``'s
+    ``csv`` / ``quarantine``). Same hash + stage + slot across runs ->
+    same key -> a cache hit on the result lands on a persisted file we
+    can restore.
+    """
+    if not local_path or not file_hash:
+        return None
+    key = f"dpp:files:{file_hash}:{stage}:{slot}"
+    return persist_file(local_path, key)
 
 
 # Module-import-time constants:
@@ -458,6 +491,13 @@ def _retry_if_transient(task, task_run, state) -> bool:
     retry_delay_seconds=[10, 60, 300],
     retry_condition_fn=_retry_if_transient,
     tags=["datapusher-plus", "io-bound"],
+    # Content-caching: skip re-downloading the same URL within the
+    # cache window. The downloaded file is persisted alongside the
+    # result so a cache hit on a later run can restore it into the
+    # current tempdir (see ``_persist_stage_file`` /
+    # ``runtime_context._resolve_or_restore``).
+    cache_policy=DOWNLOAD_CACHE_POLICY,
+    cache_expiration=DEFAULT_CACHE_EXPIRATION,
     # Persistence: every output is checkpointed so operators can inspect
     # a task's output from the Prefect UI.
     persist_result=True,
@@ -472,6 +512,9 @@ def download_task(job_input: JobInput) -> DownloadResult:
         file_hash=ctx.file_hash,
         content_length=ctx.content_length,
         downloaded_path=ctx.tmp,
+        downloaded_path_key=_persist_stage_file(
+            ctx.tmp, ctx.file_hash, "download", "downloaded"
+        ),
     )
 
 
@@ -481,6 +524,8 @@ def download_task(job_input: JobInput) -> DownloadResult:
     retry_delay_seconds=30,
     retry_condition_fn=_retry_if_transient,
     tags=["datapusher-plus", "qsv-subprocess"],
+    cache_policy=CONTENT_CACHE_POLICY,
+    cache_expiration=DEFAULT_CACHE_EXPIRATION,
     persist_result=True,
     result_storage=DEFAULT_RESULT_STORAGE,
 )
@@ -491,6 +536,9 @@ def format_convert_task(prev: DownloadResult) -> ConvertResult:
         upstream=prev,
         csv_path=ctx.tmp,
         converted_from=ctx.resource.get("format"),
+        csv_path_key=_persist_stage_file(
+            ctx.tmp, ctx.file_hash, "convert", "csv"
+        ),
     )
 
 
@@ -498,6 +546,8 @@ def format_convert_task(prev: DownloadResult) -> ConvertResult:
     name="validate",
     retries=0,
     tags=["datapusher-plus", "qsv-subprocess"],
+    cache_policy=CONTENT_CACHE_POLICY,
+    cache_expiration=DEFAULT_CACHE_EXPIRATION,
     persist_result=True,
     result_storage=DEFAULT_RESULT_STORAGE,
 )
@@ -522,6 +572,15 @@ def validate_task(prev: ConvertResult) -> ValidateResult:
         rows_after_dedup=ctx.rows_to_copy,
         quarantined_rows=ctx.quarantined_rows,
         quarantine_csv_path=ctx.quarantine_csv_path or None,
+        csv_path_key=_persist_stage_file(
+            ctx.tmp, ctx.file_hash, "validate", "csv"
+        ),
+        quarantine_csv_path_key=_persist_stage_file(
+            ctx.quarantine_csv_path or None,
+            ctx.file_hash,
+            "validate",
+            "quarantine",
+        ),
     )
 
 
@@ -531,6 +590,8 @@ def validate_task(prev: ConvertResult) -> ValidateResult:
     retry_delay_seconds=60,
     retry_condition_fn=_retry_if_transient,
     tags=["datapusher-plus", "qsv-subprocess", "cpu-bound"],
+    cache_policy=CONTENT_CACHE_POLICY,
+    cache_expiration=DEFAULT_CACHE_EXPIRATION,
     persist_result=True,
     result_storage=DEFAULT_RESULT_STORAGE,
 )
@@ -557,6 +618,9 @@ def analyze_task(prev: ValidateResult) -> AnalyzeResult:
         resource_fields_freqs=dict(ctx.resource_fields_freqs),
         pii_found=ctx.pii_found,
         pii_candidate_count=ctx.pii_candidate_count,
+        csv_path_key=_persist_stage_file(
+            ctx.tmp, ctx.file_hash, "analyze", "csv"
+        ),
     )
 
 

--- a/ckanext/datapusher_plus/jobs/runtime_context.py
+++ b/ckanext/datapusher_plus/jobs/runtime_context.py
@@ -31,9 +31,11 @@ from __future__ import annotations
 
 import contextvars
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from ckanext.datapusher_plus.jobs.context import ProcessingContext
+from ckanext.datapusher_plus.jobs.file_persistence import restore_file
 
 # ``RuntimeContext`` is the role-name for the mutable per-run state. We
 # alias it to ``ProcessingContext`` so stage signatures (``process(ctx:
@@ -129,6 +131,14 @@ class DownloadResult:
     file_hash: str
     content_length: int
     downloaded_path: str
+    # Result-storage key under which ``downloaded_path``'s contents were
+    # persisted at task completion. ``None`` when persistence skipped
+    # (no storage block, or write failed). On a cross-run cache hit,
+    # ``_apply_result`` uses this key to restore the file into the
+    # current run's tempdir. Optional + defaulting to ``None`` is
+    # back-compat: cached results from older runs predating this field
+    # deserialize cleanly and just behave as "no cross-run rehydration".
+    downloaded_path_key: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -139,6 +149,9 @@ class ConvertResult:
     csv_path: str
     # e.g. "xlsx", "shp", or None for pass-through.
     converted_from: Optional[str] = None
+    # See ``DownloadResult.downloaded_path_key`` for the rationale on
+    # this field. Set at task completion if persistence succeeded.
+    csv_path_key: Optional[str] = None
 
     @property
     def file_hash(self) -> str:
@@ -155,6 +168,9 @@ class ValidateResult:
     rows_after_dedup: int
     quarantined_rows: int = 0
     quarantine_csv_path: Optional[str] = None
+    # See ``DownloadResult.downloaded_path_key``; one key per file path.
+    csv_path_key: Optional[str] = None
+    quarantine_csv_path_key: Optional[str] = None
 
     @property
     def file_hash(self) -> str:
@@ -179,6 +195,8 @@ class AnalyzeResult:
     # Count of PII candidate matches — what the PII-review suspend gate
     # thresholds on.
     pii_candidate_count: int = 0
+    # See ``DownloadResult.downloaded_path_key``.
+    csv_path_key: Optional[str] = None
 
     @property
     def file_hash(self) -> str:
@@ -242,6 +260,36 @@ class MetadataResult:
 # mutated the shared context in this process.
 
 
+def _resolve_or_restore(
+    local_path: Optional[str], storage_key: Optional[str], dest_dir: str
+) -> Optional[str]:
+    """Return a usable local path for a file referenced by a result.
+
+    Three cases:
+
+    1. ``local_path`` exists on disk -> use it as-is (same-run case;
+       the file is still in the current tempdir).
+    2. ``local_path`` does not exist but ``storage_key`` is set ->
+       restore the persisted contents into ``dest_dir`` (the current
+       run's tempdir) under the same basename and return the new path
+       (cross-run cache-hit case).
+    3. Otherwise -> return ``local_path`` unchanged so the downstream
+       stage fails with a clear ``FileNotFoundError`` rather than
+       silently appearing to succeed on stale data.
+
+    ``None`` / empty inputs pass through unchanged.
+    """
+    if not local_path:
+        return local_path
+    if Path(local_path).is_file():
+        return local_path
+    if storage_key:
+        dest = Path(dest_dir) / Path(local_path).name
+        if restore_file(storage_key, str(dest)):
+            return str(dest)
+    return local_path
+
+
 def _apply_result(ctx: RuntimeContext, result: Any) -> None:
     """Apply one result layer's fields onto ``ctx``.
 
@@ -250,6 +298,11 @@ def _apply_result(ctx: RuntimeContext, result: Any) -> None:
     back from ``ctx`` need a branch here; ``IndexingResult`` /
     ``FormulaResult`` / ``MetadataResult`` carry nothing a downstream
     stage consumes via the context, so they have none.
+
+    Every file-path field is routed through ``_resolve_or_restore`` so
+    a cross-run cache hit (whose recorded tempdir path no longer exists)
+    transparently fetches the persisted file from result storage into
+    the current run's tempdir.
     """
     if isinstance(result, DownloadResult):
         # Defensive copy: later stages mutate ``ctx.resource`` in place
@@ -261,16 +314,31 @@ def _apply_result(ctx: RuntimeContext, result: Any) -> None:
         ctx.resource_url = result.resource_url
         ctx.file_hash = result.file_hash
         ctx.content_length = result.content_length
-        ctx.tmp = result.downloaded_path
+        ctx.tmp = _resolve_or_restore(
+            result.downloaded_path, result.downloaded_path_key, ctx.temp_dir
+        )
     elif isinstance(result, ConvertResult):
-        ctx.tmp = result.csv_path
+        ctx.tmp = _resolve_or_restore(
+            result.csv_path, result.csv_path_key, ctx.temp_dir
+        )
     elif isinstance(result, ValidateResult):
-        ctx.tmp = result.csv_path
+        ctx.tmp = _resolve_or_restore(
+            result.csv_path, result.csv_path_key, ctx.temp_dir
+        )
         ctx.rows_to_copy = result.rows_after_dedup
         ctx.quarantined_rows = result.quarantined_rows
-        ctx.quarantine_csv_path = result.quarantine_csv_path or ""
+        ctx.quarantine_csv_path = (
+            _resolve_or_restore(
+                result.quarantine_csv_path,
+                result.quarantine_csv_path_key,
+                ctx.temp_dir,
+            )
+            or ""
+        )
     elif isinstance(result, AnalyzeResult):
-        ctx.tmp = result.csv_path
+        ctx.tmp = _resolve_or_restore(
+            result.csv_path, result.csv_path_key, ctx.temp_dir
+        )
         ctx.headers = list(result.headers)
         ctx.headers_dicts = list(result.headers_dicts)
         ctx.original_header_dict = dict(result.original_header_dict)

--- a/tests/test_file_persistence.py
+++ b/tests/test_file_persistence.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+"""
+Unit coverage for the file-persistence layer that backs the re-enabled
+result caching: ``file_persistence.persist_file`` /
+``file_persistence.restore_file`` and the ``_resolve_or_restore``
+rehydration helper in ``runtime_context``.
+
+These tests stub the result-storage block with an in-memory fake so
+they run anywhere CKAN is importable (the ``dpp-test`` container, CI)
+without needing a real Prefect server.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake result-storage block — drop-in for what ``load_result_storage_block``
+# returns. Mimics Prefect's ``LocalFileSystem.{read_path,write_path}`` API.
+# ---------------------------------------------------------------------------
+
+
+class _FakeBlock:
+    """Minimal in-memory stand-in for a Prefect storage block."""
+
+    def __init__(self):
+        self.store: dict = {}
+
+    def write_path(self, key: str, content: bytes) -> None:
+        self.store[key] = content
+
+    def read_path(self, key: str) -> bytes:
+        if key not in self.store:
+            raise FileNotFoundError(key)
+        return self.store[key]
+
+
+# ---------------------------------------------------------------------------
+# persist_file / restore_file
+# ---------------------------------------------------------------------------
+
+
+def test_persist_then_restore_round_trips_file_contents(tmp_path):
+    """Happy path: write contents, key returned, restore reads them back
+    identically into a new path."""
+    pytest.importorskip("ckan")
+    from ckanext.datapusher_plus.jobs import file_persistence
+
+    src = tmp_path / "input.csv"
+    src.write_bytes(b"col1,col2\n1,2\n3,4\n")
+
+    block = _FakeBlock()
+    with mock.patch.object(
+        file_persistence, "load_result_storage_block", return_value=block
+    ):
+        key = file_persistence.persist_file(str(src), "dpp:files:abc:download:downloaded")
+        assert key == "dpp:files:abc:download:downloaded"
+        assert "dpp:files:abc:download:downloaded" in block.store
+
+        dst = tmp_path / "restored.csv"
+        ok = file_persistence.restore_file(key, str(dst))
+        assert ok is True
+        assert dst.read_bytes() == src.read_bytes()
+
+
+def test_persist_returns_none_when_block_unavailable(tmp_path):
+    """When ``load_result_storage_block`` returns ``None`` (no Prefect
+    server / unregistered block / tooling context), persist must
+    degrade silently with ``None`` so the caller can leave the result's
+    storage-key field at ``None`` and same-run chains still work."""
+    pytest.importorskip("ckan")
+    from ckanext.datapusher_plus.jobs import file_persistence
+
+    src = tmp_path / "x.csv"
+    src.write_bytes(b"...")
+
+    with mock.patch.object(
+        file_persistence, "load_result_storage_block", return_value=None
+    ):
+        assert file_persistence.persist_file(str(src), "any-key") is None
+
+
+def test_persist_returns_none_when_file_missing(tmp_path):
+    """A missing local file is handled gracefully (logged, returns
+    ``None``) — never raises."""
+    pytest.importorskip("ckan")
+    from ckanext.datapusher_plus.jobs import file_persistence
+
+    block = _FakeBlock()
+    with mock.patch.object(
+        file_persistence, "load_result_storage_block", return_value=block
+    ):
+        result = file_persistence.persist_file(
+            str(tmp_path / "does-not-exist.csv"), "k"
+        )
+    assert result is None
+    assert block.store == {}
+
+
+def test_restore_returns_false_for_missing_key(tmp_path):
+    """A missing storage key is handled gracefully (returns ``False``)
+    so the caller can fall back to letting the downstream stage raise
+    a clear ``FileNotFoundError``."""
+    pytest.importorskip("ckan")
+    from ckanext.datapusher_plus.jobs import file_persistence
+
+    block = _FakeBlock()
+    with mock.patch.object(
+        file_persistence, "load_result_storage_block", return_value=block
+    ):
+        ok = file_persistence.restore_file(
+            "nonexistent-key", str(tmp_path / "dest.csv")
+        )
+    assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# _resolve_or_restore (the rehydration helper in runtime_context)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_returns_local_path_when_file_exists(tmp_path):
+    """Same-run case: the recorded path still exists, no restore needed."""
+    pytest.importorskip("ckan")
+    from ckanext.datapusher_plus.jobs.runtime_context import _resolve_or_restore
+
+    existing = tmp_path / "in_tempdir.csv"
+    existing.write_bytes(b"still here")
+
+    result = _resolve_or_restore(str(existing), "some-key", str(tmp_path))
+    assert result == str(existing)
+
+
+def test_resolve_restores_from_storage_when_path_missing(tmp_path):
+    """Cross-run cache-hit case: the recorded path is gone (old tempdir
+    cleaned up), but the storage key resolves — restore into the
+    current tempdir and return the new path."""
+    pytest.importorskip("ckan")
+    from ckanext.datapusher_plus.jobs import file_persistence
+    from ckanext.datapusher_plus.jobs.runtime_context import _resolve_or_restore
+
+    # Seed the fake block with a saved version of the file.
+    block = _FakeBlock()
+    block.store["k1"] = b"persisted contents"
+
+    # The "old" tempdir path doesn't exist on this machine.
+    old_path = str(tmp_path / "old_tempdir" / "stage_out.csv")
+    assert not Path(old_path).exists()
+
+    # The "current" tempdir does — that's where the restored file lands.
+    current_tempdir = tmp_path / "current_tempdir"
+    current_tempdir.mkdir()
+
+    with mock.patch.object(
+        file_persistence, "load_result_storage_block", return_value=block
+    ):
+        result = _resolve_or_restore(old_path, "k1", str(current_tempdir))
+
+    expected = current_tempdir / "stage_out.csv"
+    assert result == str(expected)
+    assert expected.read_bytes() == b"persisted contents"
+
+
+def test_resolve_returns_original_path_when_neither_local_nor_storage(tmp_path):
+    """No-fallback case: tempdir path gone AND storage key missing /
+    unavailable. Return the original path so the downstream stage
+    raises a clear ``FileNotFoundError`` instead of silently appearing
+    to succeed on stale data."""
+    pytest.importorskip("ckan")
+    from ckanext.datapusher_plus.jobs import file_persistence
+    from ckanext.datapusher_plus.jobs.runtime_context import _resolve_or_restore
+
+    block = _FakeBlock()  # empty
+    missing_path = str(tmp_path / "gone.csv")
+
+    with mock.patch.object(
+        file_persistence, "load_result_storage_block", return_value=block
+    ):
+        result = _resolve_or_restore(missing_path, "absent-key", str(tmp_path))
+
+    assert result == missing_path  # unchanged
+
+
+def test_resolve_passes_through_none(tmp_path):
+    """``None`` / empty inputs pass through unchanged — common for
+    optional fields like ``quarantine_csv_path`` when validation
+    rejected zero rows."""
+    pytest.importorskip("ckan")
+    from ckanext.datapusher_plus.jobs.runtime_context import _resolve_or_restore
+
+    assert _resolve_or_restore(None, "any", str(tmp_path)) is None
+    assert _resolve_or_restore("", "any", str(tmp_path)) == ""


### PR DESCRIPTION
## Summary

Re-enables `cache_policy=` on the read-only stages and clears the file-path blocker that forced caching off in the first place (the "next step" called out in `caching.py`'s pre-existing docstring). Closes the result-caching item on #282.

### Why caching was off

Each per-stage result dataclass carries working file paths that point into a per-run `TemporaryDirectory`. Without persistence, a cached result from an earlier run referenced a tempdir that no longer exists, so a cache hit would either error or silently misread stale data downstream.

### What this PR adds

- **New `jobs/file_persistence.py`** — `persist_file(local_path, key)` + `restore_file(key, dest_path)`, both with graceful no-op fallback when the storage block isn't available.
- **Result dataclasses** gain optional `*_path_key` fields (back-compat: cached results predating the field deserialize cleanly).
- **Task bodies** persist their working file at completion via a tiny `_persist_stage_file(...)` helper using the content-hash + stage + slot as a stable key.
- **`_apply_result`** routes every file path through a new `_resolve_or_restore(...)` helper: local path if it still exists (same-run); otherwise restore from storage into the current tempdir (cross-run cache hit); otherwise pass the original path through so the downstream gets a clear `FileNotFoundError` instead of silent staleness.
- **`cache_policy=` re-enabled** on `download_task`, `format_convert_task`, `validate_task`, `analyze_task` with `cache_expiration=DEFAULT_CACHE_EXPIRATION` (24h default). Mutating tasks (database, indexing, formula, metadata) intentionally still do not cache — caching the result would skip the side effect.

### Correctness fix in `caching.py`

The pre-existing `CacheKeyFnPolicy(cache_key_fn=...) + TASK_SOURCE` composition has a subtle hazard verified empirically against Prefect 3.7: when `cache_key_fn` returns `None` (no `file_hash` yet, or operator passed `ignore_hash=True`), Prefect's `CompoundCachePolicy.compute_key` drops the `None` contribution and hashes the rest — so the compound key collapses to just the TASK_SOURCE hash, identical for every invocation of the same task source regardless of parameters. Two unrelated runs with no content key would hit each other's cache.

Fix: drop the `+ TASK_SOURCE` composition. The cost is that a DP+ upgrade changing a task body no longer auto-invalidates older cached output; the 24-hour default TTL bounds the staleness window. Operators wanting fresh output post-upgrade can clear the storage block or shorten `DATAPUSHER_PLUS_CACHE_TTL_HOURS`. Documented in `caching.py`.

### Tests

New `tests/test_file_persistence.py` with 8 cases covering persist/restore round-trip, graceful degradation paths, and the three `_resolve_or_restore` branches (local-exists / storage-restore / fall-through to clear error).

Verified locally in the `dpp-test` ckan-dev container: **60/60 unit tests pass** (52 prior + 8 new).

## Test plan

- [ ] `ci.yml` (DataPusher+ Integration CI) — the 7-file quick-dir matrix exercises the same task chain end-to-end with a real Prefect server + worker. Caching hits should be harmless on the first run (cache empty) and should make subsequent runs of the same files faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)