### PR TITLE
fix(prefect): address roborev review on #286

### DIFF
--- a/ckanext/datapusher_plus/jobs/caching.py
+++ b/ckanext/datapusher_plus/jobs/caching.py
@@ -155,37 +155,31 @@ def content_cache_key(context, parameters) -> Optional[str]:
 
 
 # ---------------------------------------------------------------------------
-# Composed cache policies
+# Cache policies
 # ---------------------------------------------------------------------------
 #
 # Prefect 3.4+ recommends ``cache_policy=...`` over the legacy
-# ``cache_key_fn=`` shorthand. Wrapping our custom keys in
-# ``CacheKeyFnPolicy`` lets us compose them with ``TASK_SOURCE`` — when
-# operators upgrade DP+ and a task body changes, the source-hash
-# component invalidates stale caches automatically. Without this, a
-# resubmit after upgrading would happily reuse output produced by the
-# old code.
+# ``cache_key_fn=`` shorthand. We deliberately do NOT compose our
+# ``CacheKeyFnPolicy`` with ``TASK_SOURCE`` — though it would be the
+# textbook "invalidate on task body change" approach, it has a
+# correctness hazard verified empirically against Prefect 3.7:
+# ``CompoundCachePolicy.compute_key`` drops ``None`` contributions and
+# hashes the rest, so when ``cache_key_fn`` returns ``None`` (no
+# ``file_hash`` propagated yet, or operator passed ``ignore_hash=True``)
+# the compound key collapses to just the TASK_SOURCE hash — identical
+# for every invocation of that task with the same task source,
+# regardless of parameters. Two unrelated runs with no content key
+# would hit each other's cache.
 #
-# Loaded lazily so the module still imports when Prefect 3.4's
-# ``cache_policies`` module isn't available (older Prefect 3.x or
-# tooling contexts).
-
-# We deliberately do NOT compose with ``TASK_SOURCE`` here. A naive
-# ``CacheKeyFnPolicy(cache_key_fn=key_fn) + TASK_SOURCE`` has a
-# correctness hazard: Prefect 3's ``CompoundCachePolicy.compute_key``
-# drops ``None`` contributions and hashes the rest, so when ``key_fn``
-# returns ``None`` (no file_hash propagated yet, or operator passed
-# ``ignore_hash=True``) the compound key collapses to just the
-# TASK_SOURCE hash — identical for every invocation of that task with
-# the same task source, regardless of parameters. Two unrelated runs
-# with no content key would hit each other's cache. Verified
-# empirically against Prefect 3.7.
-#
-# Without TASK_SOURCE, a DP+ upgrade that changes a task body does NOT
+# Trade-off: a DP+ upgrade that changes a task body does NOT
 # automatically invalidate older cached output. Operators relying on
-# fresh output after an upgrade should either delete the result-storage
+# fresh output after an upgrade should either clear the result-storage
 # Block contents or shorten ``DATAPUSHER_PLUS_CACHE_TTL_HOURS``. The
 # default 24h expiration bounds the staleness window.
+#
+# Loaded lazily inside the try-block below so the module still imports
+# when Prefect 3.4's ``cache_policies`` module isn't available (older
+# Prefect 3.x, tooling contexts).
 try:
     from prefect.cache_policies import CacheKeyFnPolicy
 

--- a/ckanext/datapusher_plus/jobs/file_persistence.py
+++ b/ckanext/datapusher_plus/jobs/file_persistence.py
@@ -28,11 +28,38 @@ caching was re-enabled.
 from __future__ import annotations
 
 import logging
+import os
 from typing import Optional
 
 from ckanext.datapusher_plus.jobs.blocks import load_result_storage_block
 
 log = logging.getLogger(__name__)
+
+
+# Skip persistence for files larger than this many MiB. ``persist_file``
+# reads the whole file into RAM before handing it to the Prefect block
+# (Prefect 3's ``LocalFileSystem.write_path`` / ``read_path`` are
+# bytes-in / bytes-out — no streaming variant), so on multi-GB CSV
+# ingestions a single task completion could OOM the worker. Skipping
+# above the threshold falls back to the pre-caching behaviour for
+# those files (same-run chains still work; cross-run cache hits don't
+# rehydrate the file and the downstream stage will surface a clear
+# ``FileNotFoundError`` instead of running out of memory).
+#
+# Operators override via ``DATAPUSHER_PLUS_MAX_PERSIST_FILE_MB``; set
+# to ``0`` to disable the cap entirely (only sensible on workers with
+# RAM to spare). The 512 MiB default is chosen so a CSV that fits in
+# Postgres' default ``work_mem`` × a typical worker box also fits in
+# RAM for one round-trip.
+def _max_persist_bytes() -> int:
+    raw = os.environ.get("DATAPUSHER_PLUS_MAX_PERSIST_FILE_MB", "512")
+    try:
+        mb = int(raw)
+    except ValueError:
+        mb = 512
+    if mb <= 0:
+        return 0  # disabled — persist everything
+    return mb * 1024 * 1024
 
 
 def persist_file(local_path: str, key: str) -> Optional[str]:
@@ -44,15 +71,30 @@ def persist_file(local_path: str, key: str) -> Optional[str]:
             from the content hash + stage name).
 
     Returns:
-        ``key`` on success, or ``None`` if the block is unavailable
-        or the write failed. Callers should treat ``None`` as "no
-        persistence recorded" — the result dataclass leaves its
-        ``*_path_key`` field at ``None`` and cross-run rehydration
-        falls back to the in-tempdir copy (which works for same-run
-        chains, just not cache hits).
+        ``key`` on success, or ``None`` if the block is unavailable,
+        the file exceeds the configured size cap, or the write failed.
+        Callers should treat ``None`` as "no persistence recorded" —
+        the result dataclass leaves its ``*_path_key`` field at
+        ``None`` and cross-run rehydration falls back to the in-tempdir
+        copy (which works for same-run chains, just not cache hits).
     """
     block = load_result_storage_block()
     if block is None:
+        return None
+    try:
+        size = os.path.getsize(local_path)
+    except OSError:
+        log.warning("Could not persist file %s: not found", local_path)
+        return None
+    cap = _max_persist_bytes()
+    if cap and size > cap:
+        log.debug(
+            "Skipping persistence of %s (%d bytes > %d-byte cap); set "
+            "DATAPUSHER_PLUS_MAX_PERSIST_FILE_MB=0 to disable the cap.",
+            local_path,
+            size,
+            cap,
+        )
         return None
     try:
         with open(local_path, "rb") as fh:
@@ -61,6 +103,9 @@ def persist_file(local_path: str, key: str) -> Optional[str]:
         log.debug("Persisted file %s to result storage as %s", local_path, key)
         return key
     except FileNotFoundError:
+        # Race: file existed at getsize() but was removed before open().
+        # Rare in practice but possible if a parallel tempdir cleanup
+        # fires; treat as "not persisted" rather than crashing the task.
         log.warning("Could not persist file %s: not found", local_path)
         return None
     except Exception as e:

--- a/tests/test_file_persistence.py
+++ b/tests/test_file_persistence.py
@@ -101,6 +101,51 @@ def test_persist_returns_none_when_file_missing(tmp_path):
     assert block.store == {}
 
 
+
+def test_persist_skips_files_above_size_cap(tmp_path, monkeypatch):
+    """Files larger than ``DATAPUSHER_PLUS_MAX_PERSIST_FILE_MB`` skip
+    persistence and return ``None`` so the worker doesn't OOM trying to
+    load a multi-GB CSV into RAM. The bytes never reach the block."""
+    pytest.importorskip("ckan")
+    from ckanext.datapusher_plus.jobs import file_persistence
+
+    src = tmp_path / "big.csv"
+    src.write_bytes(b"x" * (2 * 1024 * 1024))  # 2 MiB
+
+    monkeypatch.setenv("DATAPUSHER_PLUS_MAX_PERSIST_FILE_MB", "1")  # 1 MiB cap
+
+    block = _FakeBlock()
+    with mock.patch.object(
+        file_persistence, "load_result_storage_block", return_value=block
+    ):
+        result = file_persistence.persist_file(str(src), "k-big")
+
+    assert result is None
+    assert block.store == {}  # nothing was written
+
+
+def test_persist_cap_zero_disables_size_gate(tmp_path, monkeypatch):
+    """Setting the cap env var to ``0`` disables the gate entirely
+    (for operators with RAM to spare who want to persist everything)."""
+    pytest.importorskip("ckan")
+    from ckanext.datapusher_plus.jobs import file_persistence
+
+    src = tmp_path / "biggish.csv"
+    src.write_bytes(b"y" * (2 * 1024 * 1024))  # 2 MiB
+
+    monkeypatch.setenv("DATAPUSHER_PLUS_MAX_PERSIST_FILE_MB", "0")
+
+    block = _FakeBlock()
+    with mock.patch.object(
+        file_persistence, "load_result_storage_block", return_value=block
+    ):
+        result = file_persistence.persist_file(str(src), "k-uncapped")
+
+    assert result == "k-uncapped"
+    assert "k-uncapped" in block.store
+    assert len(block.store["k-uncapped"]) == 2 * 1024 * 1024
+
+
 def test_restore_returns_false_for_missing_key(tmp_path):
     """A missing storage key is handled gracefully (returns ``False``)
     so the caller can fall back to letting the downstream stage raise


### PR DESCRIPTION
## Summary
Addresses [roborev review #2160](https://github.com/dathere/datapusher-plus/pull/286) on the just-merged PR #286 (commit `6cdb76f`). Two of the three findings are fixed; the third is a documented false-positive skip.

### Fixes

**Medium — `caching.py`: contradictory comment blocks.**
The pre-existing "Composed cache policies" comment block explained WHY we compose `CacheKeyFnPolicy` with `TASK_SOURCE`. The new block right below said we deliberately do NOT compose. Consolidated into a single block that explains both the empirical hazard with `+ TASK_SOURCE` (Prefect 3.7's `CompoundCachePolicy.compute_key` dropping `None` contributions and collapsing to a TASK_SOURCE-only key) and the trade-off.

**Medium — `file_persistence.py`: OOM risk on multi-GB files.**
`persist_file` reads the full file into RAM before handing it to the Prefect block (Prefect 3's `LocalFileSystem.write_path` / `read_path` are bytes-in / bytes-out, no streaming variant), so on multi-GB CSV ingestions a single task completion could OOM the worker. Added `DATAPUSHER_PLUS_MAX_PERSIST_FILE_MB` (default **512 MiB**). Files above the cap skip persistence with a debug log and fall back to pre-caching same-run-only behaviour (cross-run cache hits would surface a clear `FileNotFoundError` instead of OOM). Set env var to `0` to disable the cap entirely.

### Skipped (false positive)

**Low — `analyze_task` `csv_path_key` "double-write".** Reviewer claimed `analyze_task`'s `ctx.tmp` is the same file `validate_task` already persisted, so persisting under `…:analyze:csv` is wasted. This is incorrect: `AnalysisStage` transforms `ctx.tmp` via `context.update_tmp(...)` at three sites in `stages/analysis.py` (line 180 `qsv_safenames_csv`, line 526 `qsv_slice_csv`, line 563 `qsv_applydp_csv`). The analyze:csv slot holds genuinely different bytes from validate:csv and is needed so a cross-run cache hit on `AnalyzeResult` has a real key to restore from. Logged in the roborev close comment.

### Tests
Two new cases in `tests/test_file_persistence.py`:
- `test_persist_skips_files_above_size_cap` — file above cap returns `None`, never reaches the block.
- `test_persist_cap_zero_disables_size_gate` — cap=0 disables the gate.

Verified in the `dpp-test` ckan-dev container: **62/62 unit tests pass** (60 prior + 2 new).

## Test plan
- [ ] `ci.yml` (DataPusher+ Integration CI) — quick-dir matrix still green (the size cap is well above the test files; no behaviour change for normal-sized inputs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)