### PR TITLE
feat(prefect): Prefect Variables as highest-priority runtime config

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,8 +631,21 @@ Worker-process env-var fallbacks (read when CKAN config isn't loaded in the work
 * `DATAPUSHER_PLUS_DOWNLOAD_RETRIES`
 * `DATAPUSHER_PLUS_DATABASE_RETRIES`
 * `DATAPUSHER_PLUS_CACHE_TTL_HOURS` (default 24)
+* `DATAPUSHER_PLUS_MAX_PERSIST_FILE_MB` (default 512; `0` disables the cap)
 * `DATAPUSHER_PLUS_MAX_QUARANTINE_PCT`
 * `DATAPUSHER_PLUS_RESULT_STORAGE_BLOCK`
+
+**Prefect Variables (optional, highest priority):** the flow looks up these
+Variable names at run start and uses the value when set. Set / change them
+from the Prefect UI (Variables tab) or `prefect variable set NAME VALUE`;
+takes effect on the next flow run without a worker restart.
+
+| Variable | Overrides |
+|---|---|
+| `dpp_flow_timeout` | `ckanext.datapusher_plus.flow_timeout` / `DATAPUSHER_PLUS_FLOW_TIMEOUT_SECONDS` |
+| `dpp_download_retries` | `ckanext.datapusher_plus.download_retries` / `DATAPUSHER_PLUS_DOWNLOAD_RETRIES` |
+
+Resolution order: Prefect Variable -> env var -> `ckan.ini` -> built-in default. Variable lookup failures (Prefect server unreachable, name absent, value not int-parseable) silently fall through to the next priority — operators with no Prefect Variables set see no behaviour change.
 
 ### Troubleshooting
 

--- a/ckanext/datapusher_plus/jobs/prefect_flow.py
+++ b/ckanext/datapusher_plus/jobs/prefect_flow.py
@@ -242,14 +242,45 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-def _resolve_int(env_name: str, config_key: str, default: int) -> int:
-    """Resolve an int tunable from env var → CKAN config → default.
+def _resolve_int(
+    env_name: str,
+    config_key: str,
+    default: int,
+    *,
+    prefect_var_name: Optional[str] = None,
+) -> int:
+    """Resolve an int tunable from Prefect Variable → env → ckan config → default.
 
-    Env var wins so operators and CI can override per-process without
+    When ``prefect_var_name`` is given and the Prefect API is reachable,
+    that Variable wins if set — operators can tune the value from the
+    Prefect UI without shell access to the worker. Lookup failures
+    (server unreachable, name absent, value not int-parseable) silently
+    fall through to the env / ckan.ini path.
+
+    Env wins next so operators and CI can override per-process without
     touching ``ckan.ini``. When the env var is unset, fall back to the
-    CKAN config key — useful for operators who manage all settings via
-    ``ckan.ini``. When neither is set, return ``default``.
+    CKAN config key (useful for operators who manage all settings via
+    ``ckan.ini``). When nothing is set, return ``default``.
+
+    Intentionally NOT a module-import-time call: ``Variable.get()``
+    triggers a Prefect API call (and an ephemeral server bootstrap when
+    ``PREFECT_API_URL`` is unset), which would pollute stdout during
+    ``ckan db init`` or other tooling that imports the DP+ plugin.
+    Call this from inside a running flow / task body where a Prefect
+    runtime context already exists.
     """
+    if prefect_var_name:
+        try:
+            from prefect.variables import Variable
+
+            v = Variable.get(prefect_var_name, default=None)
+            if v is not None and v != "":
+                return int(v)
+        except Exception:
+            # Prefect server unreachable, variables API unavailable on
+            # older Prefect 3.x, Variable name has unexpected type, or
+            # value isn't int-parseable — fall through to env / config.
+            pass
     env_value = os.environ.get(env_name)
     if env_value is not None and env_value != "":
         try:
@@ -1086,15 +1117,22 @@ def datapusher_plus_flow(job_input: JobInput) -> Optional[str]:
     # import-time read there. ``database_retries`` is *not* runtime-
     # resolved — see the comment block near the constants definitions
     # at the top of the module for why.
+    #
+    # ``prefect_var_name`` adds a Prefect Variable as the highest-
+    # priority source: operators can tune these values from the Prefect
+    # UI without shell access to the worker. Variable absent / Prefect
+    # unreachable → falls through to env / ckan.ini / default.
     download_retries = _resolve_int(
         "DATAPUSHER_PLUS_DOWNLOAD_RETRIES",
         "ckanext.datapusher_plus.download_retries",
         3,
+        prefect_var_name="dpp_download_retries",
     )
     flow_timeout_seconds = _resolve_int(
         "DATAPUSHER_PLUS_FLOW_TIMEOUT_SECONDS",
         "ckanext.datapusher_plus.flow_timeout",
         7200,
+        prefect_var_name="dpp_flow_timeout",
     )
     flow_start = time.monotonic()
 

--- a/tests/test_prefect_flow.py
+++ b/tests/test_prefect_flow.py
@@ -794,3 +794,88 @@ def test_flow_aborts_when_soft_deadline_exceeded(
     assert mark_errored.called
     err_msg = mark_errored.call_args[0][1]
     assert "Flow exceeded configured timeout of 0s" in err_msg
+
+
+
+def test_resolve_int_prefect_variable_wins_when_set(monkeypatch):
+    """When a Prefect Variable is set, it overrides env and ckan.config.
+
+    Operators can tune these knobs from the Prefect UI without shell
+    access to the worker; the Variable wins over the lower-priority
+    sources documented in README.md.
+    """
+    from unittest import mock
+
+    from ckanext.datapusher_plus.jobs import prefect_flow
+
+    # Set env to a known value so we can prove the Variable wins over
+    # both (env > ckan.config, so env is the strongest competing source
+    # in this test).
+    monkeypatch.setenv("DATAPUSHER_PLUS_FLOW_TIMEOUT_SECONDS", "111")
+
+    fake_variable = mock.MagicMock()
+    fake_variable.get = mock.MagicMock(return_value="999")
+    with mock.patch.dict(
+        "sys.modules", {"prefect.variables": mock.MagicMock(Variable=fake_variable)}
+    ):
+        result = prefect_flow._resolve_int(
+            "DATAPUSHER_PLUS_FLOW_TIMEOUT_SECONDS",
+            "ckanext.datapusher_plus.flow_timeout",
+            7200,
+            prefect_var_name="dpp_flow_timeout",
+        )
+
+    assert result == 999
+    fake_variable.get.assert_called_once_with("dpp_flow_timeout", default=None)
+
+
+def test_resolve_int_falls_through_when_variable_absent(monkeypatch):
+    """An unset Prefect Variable (``Variable.get`` returns ``None``)
+    falls through to the env-var path with no error — operators who
+    don't use Prefect Variables see no behaviour change.
+    """
+    from unittest import mock
+
+    from ckanext.datapusher_plus.jobs import prefect_flow
+
+    monkeypatch.setenv("DATAPUSHER_PLUS_FLOW_TIMEOUT_SECONDS", "222")
+
+    fake_variable = mock.MagicMock()
+    fake_variable.get = mock.MagicMock(return_value=None)  # Variable absent
+    with mock.patch.dict(
+        "sys.modules", {"prefect.variables": mock.MagicMock(Variable=fake_variable)}
+    ):
+        result = prefect_flow._resolve_int(
+            "DATAPUSHER_PLUS_FLOW_TIMEOUT_SECONDS",
+            "ckanext.datapusher_plus.flow_timeout",
+            7200,
+            prefect_var_name="dpp_flow_timeout",
+        )
+
+    assert result == 222  # env-var value wins
+
+
+def test_resolve_int_falls_through_when_prefect_unreachable(monkeypatch):
+    """A Prefect server connection failure (``Variable.get`` raises)
+    falls through silently to env / config — the Variable lookup must
+    never break a flow that worked before Variables were configured.
+    """
+    from unittest import mock
+
+    from ckanext.datapusher_plus.jobs import prefect_flow
+
+    monkeypatch.setenv("DATAPUSHER_PLUS_FLOW_TIMEOUT_SECONDS", "333")
+
+    fake_variable = mock.MagicMock()
+    fake_variable.get = mock.MagicMock(side_effect=RuntimeError("connection refused"))
+    with mock.patch.dict(
+        "sys.modules", {"prefect.variables": mock.MagicMock(Variable=fake_variable)}
+    ):
+        result = prefect_flow._resolve_int(
+            "DATAPUSHER_PLUS_FLOW_TIMEOUT_SECONDS",
+            "ckanext.datapusher_plus.flow_timeout",
+            7200,
+            prefect_var_name="dpp_flow_timeout",
+        )
+
+    assert result == 333  # Variable raised → fall through to env


### PR DESCRIPTION
## Summary

Addresses plan item H on #282: lets operators tune runtime-tunable values from the **Prefect UI** (Variables tab) without shell access to the worker. Resolution order becomes: **Prefect Variable -> env -> `ckan.ini` -> built-in default**. Lookup failures silently fall through, so operators not using Variables see no behaviour change.

## What changed

- `_resolve_int` gains an optional `prefect_var_name` kwarg. When given (and the Prefect API is reachable), the Variable wins; otherwise the existing env / ckan.config / default chain runs unchanged.
- Two flow-body knobs gain a Variable name:
  - `dpp_flow_timeout` → flow_timeout (`DATAPUSHER_PLUS_FLOW_TIMEOUT_SECONDS` / `ckanext.datapusher_plus.flow_timeout`)
  - `dpp_download_retries` → download retry count
- README's "Configuration reference" section documents both Variable names + the resolution order.

## What did not change (and why)

The `@flow` decorator's `timeout_seconds=_FLOW_TIMEOUT_SECONDS` and the `@task` decorator's `retries=_TASK_RETRY_DATABASE` keep their existing env / ckan.ini-only path. `Variable.get()` triggers a Prefect API call (and an ephemeral-server bootstrap when `PREFECT_API_URL` is unset), which would pollute stdout / break tooling during `ckan db init` and any other CKAN admin command that imports the DP+ plugin. The `_resolve_int` docstring spells this out: call sites must be inside a running flow / task body where a Prefect runtime context already exists.

## Tests

Three new cases in `tests/test_prefect_flow.py`:
- `test_resolve_int_prefect_variable_wins_when_set` — Variable beats env.
- `test_resolve_int_falls_through_when_variable_absent` — `Variable.get(...) → None` falls through to env.
- `test_resolve_int_falls_through_when_prefect_unreachable` — `Variable.get(...)` raising never breaks the flow.

Verified locally in `dpp-test`: **65/65 unit tests pass** (62 prior + 3 new).

## Test plan
- [ ] `ci.yml` (DataPusher+ Integration CI) — quick-dir matrix still green. (No Variable will be set in CI, so the new code path falls through to env / config exactly as before.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)