### PR TITLE
fix(prefect): address roborev review on #289

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,7 +618,7 @@ DP+ ships two **subflow primitives** in `ckanext.datapusher_plus.jobs.subflows` 
 
 | Subflow | Wraps | Use when… |
 |---|---|---|
-| `pii_screening_subflow(csv_path, resource, temp_dir, qsv_bin=None)` | `screen_for_pii` | You want PII screening to retry / observe independently of analysis, or you're A/B-testing a custom screening implementation. |
+| `pii_screening_subflow(csv_path, resource, temp_dir)` | `screen_for_pii` | You want PII screening to retry / observe independently of analysis, or you're A/B-testing a custom screening implementation. |
 | `spatial_processing_subflow(input_path, resource_format, output_csv_path=None, tolerance=0.001)` | `process_spatial_file` | You want spatial conversion (Shapefile/GeoJSON → CSV) to retry / observe independently of the broader format-conversion task. |
 
 Both return a JSON-encodable dict (`{"pii_found": …, "pii_candidate_count": …}` and `{"success": …, "error_message": …, "bounds": …}`) so Prefect's result-serialization works without extra schema setup.

--- a/ckanext/datapusher_plus/jobs/subflows.py
+++ b/ckanext/datapusher_plus/jobs/subflows.py
@@ -63,7 +63,6 @@ def pii_screening_subflow(
     csv_path: Union[str, Path],
     resource: Dict[str, Any],
     temp_dir: Union[str, Path],
-    qsv_bin: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Screen a CSV for PII via ``screen_for_pii``, as an independently
     observable Prefect subflow.
@@ -77,9 +76,6 @@ def pii_screening_subflow(
             flow's ``TemporaryDirectory``; passing it through avoids
             the subflow inventing a new one and losing artifacts on
             success.
-        qsv_bin: Optional explicit path to the qsv binary. When ``None``,
-            ``QSVCommand`` resolves it from ``ckanext.datapusher_plus
-            .qsv_bin`` / ``$QSV_BIN``.
 
     Returns:
         Dict with two keys:
@@ -92,6 +88,14 @@ def pii_screening_subflow(
         Dict (rather than a dataclass) for Prefect serialization
         simplicity at the subflow boundary — Prefect's result encoding
         handles built-ins without extra schema work.
+
+    Note:
+        The qsv binary path is always resolved by ``QSVCommand`` from
+        ``ckanext.datapusher_plus.qsv_bin`` (with ``$QSV_BIN`` fallback).
+        A per-call override is not supported because ``QSVCommand``
+        itself doesn't expose one; if the use case arises, add the
+        override to ``QSVCommand.__init__`` first and then thread it
+        through here.
     """
     log = _runtime_logger()
     qsv = QSVCommand(logger=log)
@@ -152,9 +156,18 @@ def spatial_processing_subflow(
         log,
     )
     if success:
+        # When ``output_csv_path`` is ``None``, ``process_spatial_file``
+        # writes alongside ``input_path`` with a ``.csv`` extension —
+        # surface that in the log instead of the misleading ``None``
+        # operators most need to debug ("where did my CSV go?").
+        effective_output = (
+            output_csv_path
+            if output_csv_path is not None
+            else str(Path(input_path).with_suffix(".csv"))
+        )
         log.info(
             f"Spatial conversion complete: bounds={bounds}, "
-            f"output={output_csv_path}"
+            f"output={effective_output}"
         )
     else:
         log.error(f"Spatial conversion failed: {error_message}")

--- a/tests/test_subflows.py
+++ b/tests/test_subflows.py
@@ -44,7 +44,11 @@ def subflows():
 def test_pii_subflow_forwards_args_and_shapes_result(subflows, tmp_path):
     """The subflow calls ``screen_for_pii`` with the forwarded args
     and packages the ``(pii_found, count)`` tuple into the documented
-    dict shape."""
+    dict shape. The constructed ``QSVCommand`` instance reaches the
+    helper as the third positional argument — without this assertion,
+    a regression that swapped the call order or dropped the
+    ``QSVCommand`` would slip through.
+    """
     csv = tmp_path / "x.csv"
     csv.write_text("col1,col2\n1,2\n")
 
@@ -59,13 +63,13 @@ def test_pii_subflow_forwards_args_and_shapes_result(subflows, tmp_path):
 
     assert result == {"pii_found": True, "pii_candidate_count": 3}
     screen.assert_called_once()
-    # ``QSVCommand`` is constructed inside the subflow with the run
-    # logger, then forwarded as the third positional arg to
-    # ``screen_for_pii``.
     qsv_class.assert_called_once()
     args, _ = screen.call_args
     assert args[0] == str(csv)
     assert args[1] == {"format": "CSV", "url": "x"}
+    # The QSVCommand instance constructed inside the subflow is
+    # forwarded as the third positional arg.
+    assert args[2] is qsv_class.return_value
     assert args[3] == str(tmp_path)
 
 


### PR DESCRIPTION
## Summary
Addresses [roborev review #2163](https://github.com/dathere/datapusher-plus/pull/289) on the just-merged PR #289 (commit `f970993`). All three findings fixed.

### Fixes

**Medium — `subflows.py` `pii_screening_subflow`: unused `qsv_bin` parameter.**
The parameter was accepted and documented but never plumbed through — `QSVCommand.__init__` only takes `logger`. Dropped the parameter (reviewer's option b — YAGNI). Docstring now notes how to add it back if the use case arises: extend `QSVCommand.__init__` first, then thread it through.

**Low — `test_subflows.py`: missing QSVCommand-forwarding assertion.**
Pre-existing test comment claimed `QSVCommand` was "forwarded as the third positional arg" but never asserted it. Added `assert args[2] is qsv_class.return_value`.

**Low — `subflows.py` `spatial_processing_subflow`: misleading success log.**
When `output_csv_path=None`, `process_spatial_file` writes alongside `input_path` with a `.csv` extension — but the log said `output=None`, exactly the misleading line operators most need to debug. Success branch now derives the effective path: `Path(input_path).with_suffix(".csv")` when the kwarg is `None`.

### Tests
70/70 unit tests still pass in `dpp-test` (count unchanged — finding 1 dropped a parameter, no new test needed; finding 2 strengthened an existing test).

## Test plan
- [ ] `ci.yml` (DataPusher+ Integration CI) — quick-dir matrix still green. The default flow doesn't invoke either subflow, so no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)