### PR TITLE
docs(readme): fix installation-step numbering + drop RQ worker reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,11 +380,17 @@ sudo chown rzmk /var/lib/ckan/default
 sudo chmod -R u+rwx /var/lib/ckan/default
 ```
 
-10. Make sure you enable the [Datastore](https://docs.ckan.org/en/2.11/maintaining/datastore.html) plugin.
-11. In a separate terminal start the job queue:
+12. Make sure you enable the [Datastore](https://docs.ckan.org/en/2.11/maintaining/datastore.html) plugin.
+13. In a separate terminal, start a Prefect worker subscribed to the
+    DP+ work pool. v3.0 replaced the RQ `ckan jobs worker` with a
+    Prefect worker; see the [Worker lifecycle](#worker-lifecycle)
+    section below for the full command and lifecycle details. Quick
+    reference:
 
 ```bash
-ckan -c /etc/ckan/default/ckan.ini jobs worker
+PREFECT_API_URL=http://prefect-server:4200/api \
+CKAN_INI=/etc/ckan/default/ckan.ini \
+prefect worker start --pool datapusher-plus
 ```
 
 ## Configuring


### PR DESCRIPTION
## Summary

Closes #226.

The original issue flagged \`-p datapusher_plus\` (with underscore) as a possible typo. **That's actually correct** — it's the CKAN plugin entry-point key (\`[project.entry-points.\"ckan.plugins\"]\` in pyproject.toml line 43). Only the package name uses a hyphen.

But two real bugs surfaced in that section:

1. **Steps 10-11 were duplicated.** The installation list went \`9. Set up the database\` → \`10. ValidationError troubleshooting\` → \`11. FileStore setup\` → \`10. Datastore plugin\` (reset!) → \`11. Job queue worker\`. Renumbered the second pair to 12-13.

2. **Step 13 still referenced \`ckan jobs worker\` (RQ era).** DP+ 3.0 replaced RQ with a Prefect worker. Now points readers to the §Worker lifecycle section already in the README, with an inline quick-reference snippet so they don't have to scroll.

## Test plan
- [ ] Read the renumbered installation steps top-to-bottom; numbering reads 1 → 13 with no jumps or duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)