### PR TITLE
fix(analysis): pass reserved/prefix to safenames sanitize call (rebases #267)

### DIFF
--- a/ckanext/datapusher_plus/jobs/stages/analysis.py
+++ b/ckanext/datapusher_plus/jobs/stages/analysis.py
@@ -174,8 +174,17 @@ class AnalysisStage(BaseStage):
                 f"({unsafe_headers}). Sanitizing...\""
             )
             qsv_safenames_csv = os.path.join(context.temp_dir, "qsv_safenames.csv")
+            # Mirror the ``reserved`` / ``prefix`` args from the detect call
+            # above so the sanitize step uses the same rules. Without them
+            # qsv falls back to its built-in defaults, which can disagree
+            # with what was reported as unsafe — yielding renamed columns
+            # that don't match the detection output.
             context.qsv.safenames(
-                context.tmp, mode="conditional", output_file=qsv_safenames_csv
+                context.tmp,
+                mode="conditional",
+                reserved=conf.RESERVED_COLNAMES,
+                prefix=conf.UNSAFE_PREFIX,
+                output_file=qsv_safenames_csv,
             )
             context.update_tmp(qsv_safenames_csv)
         else:


### PR DESCRIPTION
## Summary

Cherry-picks [#267](https://github.com/dathere/datapusher-plus/pull/267) (by @minhajuddin2510) onto current main. The migration deleted \`jobs.py\` (where #267's 1-line change lived) so the original PR became dead-on-main — same situation as #270.

### What the change does

Brings the qsv \`safenames --mode conditional\` (sanitize) call into parity with the \`--mode json\` (detect) call directly above it in \`analysis.py\`. The detect call already passes \`reserved=conf.RESERVED_COLNAMES\` + \`prefix=conf.UNSAFE_PREFIX\`; the sanitize call didn't, so qsv fell back to its built-in defaults — which could disagree with the detection rules and produce renamed columns that didn't match what was reported as unsafe.

### Tests
95/95 unit tests pass in \`dpp-test\`.

## Test plan
- [ ] \`ci.yml\` (DataPusher+ Integration CI) — quick-dir matrix still green; no regression on files with unsafe column names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)