### PR TITLE
build: include MANIFEST.in data files in the wheel (rebases #252)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,12 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = { find = { where = ["."], exclude = ["tests*"] } }
+# Tell setuptools to include MANIFEST.in-listed data files (yaml, json, html,
+# js, mo, etc.) inside the *wheel* as well, not just the sdist. Without this,
+# `pip install datapusher-plus` from PyPI builds a wheel that omits
+# `config_declaration.yaml` and the bundled templates/JS — surfaces as
+# "config_declaration.yaml file is missing" at plugin load time (see #251).
+include-package-data = true
 
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }


### PR DESCRIPTION
## Summary

Cherry-picks the intent of [#252](https://github.com/dathere/datapusher-plus/pull/252) (by @avdata99, related to #251) onto current main. Closes #252.

### What the bug was

\`pip install datapusher-plus\` from PyPI built a wheel that omitted \`config_declaration.yaml\` and the bundled templates/JS, surfacing as the "config_declaration.yaml file is missing" plugin-load error from #251. The sdist had always been correct because setuptools honours \`MANIFEST.in\` for sdist builds by default; the wheel path requires an explicit opt-in.

### Fix
Add \`include-package-data = true\` under \`[tool.setuptools]\` in \`pyproject.toml\`. (#252 added \`include_package_data=True\` to setup.py, which is now a babel-only shim post-#274 — same intent, different file.)

### Verification

\`\`\`
$ python3 -m pip wheel --no-deps -w /tmp/whl /repo
$ unzip -l /tmp/whl/datapusher_plus-*.whl | grep yaml
ckanext/datapusher_plus/config_declaration.yaml
ckanext/datapusher_plus/dataset-druf.yaml
\`\`\`

## Test plan
- [ ] \`ci.yml\` (DataPusher+ Integration CI) — quick-dir matrix still green. No runtime behaviour change; this only affects what's packaged in the wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)