### PR TITLE
fix(metadata): blank Date/DateTime mean in summary-stats CSV (rebases #254)

### DIFF
--- a/ckanext/datapusher_plus/jobs/stages/metadata.py
+++ b/ckanext/datapusher_plus/jobs/stages/metadata.py
@@ -5,6 +5,7 @@ Metadata stage for the DataPusher Plus pipeline.
 Handles resource metadata updates, auto-aliasing, and summary statistics.
 """
 
+import csv
 import os
 import time
 import psycopg2
@@ -274,6 +275,16 @@ class MetadataStage(BaseStage):
 
         new_stats_resource_id = stats_response["result"]["resource_id"]
 
+        # qsv's stats CSV reports ``mean`` as an ISO date string for Date /
+        # DateTime fields (e.g. "2025-03-01" for the average day in a
+        # date column), but the summary-stats table declares ``mean
+        # FLOAT`` — so a direct COPY raises
+        # ``invalid input syntax for type double precision: "2025-03-01"``
+        # and the whole stats load aborts. Rewrite the stats CSV with
+        # ``mean`` blanked out on Date/DateTime rows before the COPY.
+        # The numeric mean for actual numeric fields is preserved.
+        qsv_stats_csv = self._blank_date_means(context, qsv_stats_csv)
+
         # Copy stats data to datastore
         self._copy_stats_to_datastore(
             context, cursor, qsv_stats_csv, new_stats_resource_id, stats_stats_dict
@@ -318,6 +329,52 @@ class MetadataStage(BaseStage):
                 existing_stats_alias_of = stats_alias_result[0]
                 dsu.delete_datastore_resource(existing_stats_alias_of)
                 dsu.delete_resource(existing_stats_alias_of)
+
+    def _blank_date_means(
+        self, context: ProcessingContext, qsv_stats_csv: str
+    ) -> str:
+        """Rewrite the qsv stats CSV with ``mean`` blanked on Date/DateTime rows.
+
+        qsv reports a Date column's ``mean`` as an ISO-formatted date
+        string (e.g. ``"2025-03-01"`` for the average day across the
+        column). The summary-statistics table declares ``mean FLOAT``,
+        so a direct ``COPY`` raises ``invalid input syntax for type
+        double precision``. Blanking the cell lets Postgres land NULL
+        in the FLOAT column instead. Numeric-field means are
+        untouched.
+
+        Args:
+            context: Processing context (used for ``temp_dir`` only).
+            qsv_stats_csv: Path to the raw qsv stats CSV.
+
+        Returns:
+            Path to the cleaned stats CSV. When no Date/DateTime rows
+            are present, returns ``qsv_stats_csv`` unchanged so we
+            don't rewrite the file for nothing.
+        """
+        cleaned_path = os.path.join(context.temp_dir, "qsv_stats_cleaned.csv")
+        rewrote = False
+        with open(qsv_stats_csv, "r", newline="") as src, open(
+            cleaned_path, "w", newline=""
+        ) as dst:
+            reader = csv.DictReader(src)
+            writer = csv.DictWriter(dst, fieldnames=reader.fieldnames)
+            writer.writeheader()
+            for row in reader:
+                if row.get("type") in ("Date", "DateTime") and row.get("mean"):
+                    row["mean"] = ""
+                    rewrote = True
+                writer.writerow(row)
+        if not rewrote:
+            # Avoid handing downstream a different path when nothing
+            # changed — keeps the file-handling path identical for the
+            # common all-numeric case.
+            os.remove(cleaned_path)
+            return qsv_stats_csv
+        context.logger.info(
+            f"Blanked Date/DateTime mean values in stats CSV → {cleaned_path}"
+        )
+        return cleaned_path
 
     def _infer_stats_schema(
         self, context: ProcessingContext, qsv_stats_csv: str

--- a/tests/test_metadata_stats_cleanup.py
+++ b/tests/test_metadata_stats_cleanup.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+"""
+Unit coverage for ``MetadataStage._blank_date_means``.
+
+Regression test for the bug originally reported in #254 by
+@avdata99: qsv reports a Date/DateTime column's ``mean`` as an
+ISO date string (e.g. ``"2025-03-01"``), but the summary-stats
+table declares ``mean FLOAT`` so a direct COPY trips
+``invalid input syntax for type double precision``.
+"""
+
+from __future__ import annotations
+
+import csv
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture
+def stage():
+    """Import the metadata stage lazily — its top-level imports need
+    psycopg2 and the CKAN-dependent helpers."""
+    pytest.importorskip("ckan")
+    pytest.importorskip("psycopg2")
+    from ckanext.datapusher_plus.jobs.stages.metadata import MetadataStage
+
+    return MetadataStage()
+
+
+def _write_stats_csv(path, rows):
+    """Write a minimal qsv-style stats CSV with the columns the
+    helper looks at."""
+    with open(path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["field", "type", "mean"])
+        w.writeheader()
+        w.writerows(rows)
+
+
+def _read_csv(path):
+    with open(path) as f:
+        return list(csv.DictReader(f))
+
+
+def test_blank_date_means_blanks_date_and_datetime_rows(stage, tmp_path):
+    """Date and DateTime rows have ``mean`` blanked; numeric rows pass
+    through unchanged. Returns the new path so the caller uses the
+    cleaned file."""
+    src = tmp_path / "qsv_stats.csv"
+    _write_stats_csv(
+        src,
+        [
+            {"field": "id", "type": "Integer", "mean": "42"},
+            {"field": "score", "type": "Float", "mean": "3.14"},
+            {"field": "born_on", "type": "Date", "mean": "1990-01-01"},
+            {"field": "logged_at", "type": "DateTime", "mean": "2025-03-01T12:00"},
+        ],
+    )
+    ctx = mock.MagicMock()
+    ctx.temp_dir = str(tmp_path)
+
+    result_path = stage._blank_date_means(ctx, str(src))
+
+    assert result_path != str(src)  # a new file was written
+    rows = _read_csv(result_path)
+    by_field = {r["field"]: r for r in rows}
+    assert by_field["id"]["mean"] == "42"
+    assert by_field["score"]["mean"] == "3.14"
+    assert by_field["born_on"]["mean"] == ""
+    assert by_field["logged_at"]["mean"] == ""
+
+
+def test_blank_date_means_returns_original_when_no_date_rows(stage, tmp_path):
+    """No Date/DateTime rows → don't write a new file, return the
+    original path. Keeps the file-handling path identical for the
+    common all-numeric case (no spurious tempfile creation)."""
+    src = tmp_path / "qsv_stats.csv"
+    _write_stats_csv(
+        src,
+        [
+            {"field": "id", "type": "Integer", "mean": "42"},
+            {"field": "score", "type": "Float", "mean": "3.14"},
+        ],
+    )
+    ctx = mock.MagicMock()
+    ctx.temp_dir = str(tmp_path)
+
+    result_path = stage._blank_date_means(ctx, str(src))
+
+    assert result_path == str(src)
+    # No leftover cleaned file:
+    assert not (tmp_path / "qsv_stats_cleaned.csv").exists()
+
+
+def test_blank_date_means_handles_empty_mean(stage, tmp_path):
+    """A Date row whose ``mean`` is already empty doesn't trigger the
+    rewrite (no work to do). Numeric rows with empty mean (rare but
+    possible) pass through unchanged."""
+    src = tmp_path / "qsv_stats.csv"
+    _write_stats_csv(
+        src,
+        [
+            {"field": "born_on", "type": "Date", "mean": ""},
+            {"field": "score", "type": "Float", "mean": "3.14"},
+        ],
+    )
+    ctx = mock.MagicMock()
+    ctx.temp_dir = str(tmp_path)
+
+    result_path = stage._blank_date_means(ctx, str(src))
+
+    # No date row needed blanking → returns original
+    assert result_path == str(src)


### PR DESCRIPTION
## Summary

Fixes the COPY failure reported in [#254](https://github.com/dathere/datapusher-plus/pull/254) by @avdata99:

\`\`\`
Error: invalid input syntax for type double precision: "2025-03-01"
CONTEXT: COPY <stats-table>, line 7, column mean: "2025-03-01"
\`\`\`

### Root cause
qsv reports a Date / DateTime column's \`mean\` as an ISO-formatted date string (the average day across the column), but the summary-statistics table declares \`mean FLOAT\` — direct COPY trips a type mismatch and the whole stats load aborts. Surfaces on any resource whose schema has a Date or DateTime column.

### Fix
A new \`MetadataStage._blank_date_means\` helper rewrites the qsv stats CSV with the \`mean\` cell blanked on Date / DateTime rows BEFORE the COPY. Numeric-field means are preserved. When no Date/DateTime rows are present, the helper short-circuits and returns the original path so the common all-numeric case doesn't pay the cost of a spurious tempfile.

### Rebase vs #254
#254 added the cleanup inline in the pre-migration \`jobs.py\`. This PR carries the equivalent fix into the new \`jobs/stages/metadata.py\` location, refactored as a method on \`MetadataStage\` so it's unit-testable.

### Tests
Three new cases in \`tests/test_metadata_stats_cleanup.py\`:
- Date + DateTime rows blanked; numeric preserved
- No Date rows → no rewrite, returns the original path (verifies short-circuit)
- Already-empty mean → no rewrite

Verified locally in \`dpp-test\`: **98/98 unit tests pass** (95 prior + 3 new).

Closes #254.

## Test plan
- [ ] \`ci.yml\` (DataPusher+ Integration CI) — quick-dir matrix still green. The errored-date.csv attached to #254 would be a perfect addition to the regression matrix in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)