### PR TITLE
fix(database): narrow TRUNCATE error swallow + clarify VACUUM comment

### DIFF
--- a/ckanext/datapusher_plus/jobs/stages/database.py
+++ b/ckanext/datapusher_plus/jobs/stages/database.py
@@ -182,8 +182,11 @@ class DatabaseStage(BaseStage):
 
             # VACUUM ANALYZE for performance. Cheap when FREEZE was used
             # (most pages already marked clean), more substantial work
-            # when it wasn't — but the ingestion has already returned
-            # from the operator's point of view.
+            # when it wasn't — but the COPY has already committed by
+            # this point, so concurrent reads of the table proceed
+            # while VACUUM runs. The operator's flow run blocks until
+            # VACUUM finishes, which is the right trade-off for
+            # write-once / read-many ingestion patterns.
             self._vacuum_analyze(raw_connection, context.resource_id)
 
             return copied_count
@@ -200,30 +203,50 @@ class DatabaseStage(BaseStage):
     ) -> None:
         """Truncate table to enable COPY FREEZE optimization.
 
-        Intentionally non-fatal: if the table doesn't exist yet (a brand
-        new resource), TRUNCATE raises and we want the subsequent
-        ``_create_datastore_table`` / COPY path to proceed anyway. But
-        a failed TRUNCATE leaves the transaction in the
-        ``InFailedSqlTransaction`` state — every subsequent statement
-        on the same connection (including the explicit ``commit()`` in
-        the opt-out branch of ``_copy_data``) raises until a
-        ``rollback()``. Roll back here so callers always observe a
-        clean transaction state on return, regardless of which branch
-        of ``_copy_data`` invoked us.
+        Intentionally non-fatal *only* when the table doesn't exist yet
+        (a brand-new resource) — TRUNCATE raises ``UndefinedTable`` and
+        we want the subsequent ``_create_datastore_table`` / COPY path
+        to proceed anyway. Every other ``psycopg2.Error`` (permission
+        denied, lock timeout, disk full, etc.) propagates as a
+        ``JobError`` so the job fails loudly rather than COPYing into a
+        non-truncated table that might already hold rows from a prior
+        run.
+
+        On the swallowed ``UndefinedTable`` path, we ``rollback()`` to
+        clear the aborted-transaction state so the caller's subsequent
+        ``commit()`` (in the opt-out branch of ``_copy_data``) doesn't
+        trip over ``InFailedSqlTransaction``.
 
         Args:
-            cursor: Database cursor
-            connection: Owning connection (for the rollback on failure)
-            resource_id: Resource ID (table name)
+            cursor: Database cursor.
+            connection: Owning connection (for the rollback on the
+                non-fatal branch).
+            resource_id: Resource ID (table name).
+
+        Raises:
+            utils.JobError: For any ``psycopg2.Error`` other than the
+                expected ``UndefinedTable`` ("relation does not exist").
         """
         try:
             cursor.execute(
                 sql.SQL("TRUNCATE TABLE {}").format(sql.Identifier(resource_id))
             )
-        except psycopg2.Error:
-            # Non-fatal: clear the aborted-transaction state so the
-            # caller's subsequent commit / COPY doesn't trip over it.
+        except psycopg2.errors.UndefinedTable:
+            # Expected: brand-new resource, table doesn't exist yet.
+            # Clear the aborted-transaction state so the caller's
+            # subsequent commit / COPY doesn't trip over it.
             connection.rollback()
+        except psycopg2.Error as e:
+            # Anything else (permission denied, lock timeout, disk
+            # full, ...) is not safe to silently swallow: continuing
+            # would COPY into a table that may already hold rows from
+            # a prior run. Rollback to leave the txn clean, then
+            # re-raise as a JobError so the flow's exception path
+            # records the failure on the Jobs row.
+            connection.rollback()
+            raise utils.JobError(
+                f"TRUNCATE TABLE {resource_id} failed: {e}"
+            ) from e
 
     def _vacuum_analyze(
         self, connection: psycopg2.extensions.connection, resource_id: str

--- a/tests/test_database_copy_strategy.py
+++ b/tests/test_database_copy_strategy.py
@@ -121,19 +121,44 @@ def test_copy_data_without_freeze_omits_freeze_and_double_commits(
     assert conn.commit.call_count == 2
 
 
-def test_truncate_table_rollback_on_error(stage):
-    """``_truncate_table`` rolls back on psycopg2 errors so the
-    transaction state is clean for the caller's subsequent
-    ``commit()`` in the opt-out path. Without this, the explicit
-    commit would hit ``InFailedSqlTransaction``."""
+def test_truncate_table_rollback_on_undefined_table(stage):
+    """``_truncate_table`` swallows the expected ``UndefinedTable``
+    error (table doesn't exist yet on a brand-new resource) and rolls
+    back so the caller's subsequent ``commit()`` doesn't hit
+    ``InFailedSqlTransaction`` in the opt-out path."""
     import psycopg2
 
     cur = mock.MagicMock()
-    cur.execute.side_effect = psycopg2.Error("relation does not exist")
+    cur.execute.side_effect = psycopg2.errors.UndefinedTable(
+        "relation \"missing-resource-id\" does not exist"
+    )
     conn = mock.MagicMock()
 
-    # Must not raise (the swallowed-error contract).
+    # Must not raise (the swallowed-error contract for this specific
+    # error class).
     stage._truncate_table(cur, conn, "missing-resource-id")
 
     # Rollback called once to clear the aborted transaction.
+    conn.rollback.assert_called_once()
+
+
+def test_truncate_table_reraises_other_errors_as_jobsterror(stage):
+    """Any ``psycopg2.Error`` other than ``UndefinedTable`` must
+    propagate as a ``JobError`` so the job fails loudly rather than
+    COPYing into a non-truncated table holding rows from a prior run.
+    Connection is still rolled back to leave the txn state clean."""
+    import psycopg2
+
+    from ckanext.datapusher_plus import utils
+
+    cur = mock.MagicMock()
+    cur.execute.side_effect = psycopg2.errors.InsufficientPrivilege(
+        "permission denied for table some-resource-id"
+    )
+    conn = mock.MagicMock()
+
+    with pytest.raises(utils.JobError, match="TRUNCATE TABLE"):
+        stage._truncate_table(cur, conn, "some-resource-id")
+
+    # Rollback fires before the raise so the txn isn't left aborted.
     conn.rollback.assert_called_once()


### PR DESCRIPTION
## Summary

Follow-up to #296. Addresses both unresolved Copilot inline comments on the merged PR.

### 1. Narrow the TRUNCATE error swallow

PR #296 added \`connection.rollback()\` on every \`psycopg2.Error\` from TRUNCATE — combined with the existing \"non-fatal, continue\" pattern, real failures (permission denied, lock timeout, disk full) would silently disappear, and the COPY would then run into a non-truncated table that might already hold rows from a prior run.

Now we catch only \`psycopg2.errors.UndefinedTable\` specifically (the legitimate \"brand-new resource, table doesn't exist yet\" path) and re-raise everything else as a \`JobError\` so the flow's exception path records the failure on the Jobs row. \`connection.rollback()\` still fires on both branches so the txn state is always clean.

New test \`test_truncate_table_reraises_other_errors_as_jobsterror\` covers the re-raise path with \`InsufficientPrivilege\`; existing rollback test renamed to reflect the narrower contract.

### 2. Clarify the VACUUM comment

The previous text claimed the ingestion had \"already returned from the operator's point of view\" but \`_vacuum_analyze\` runs synchronously before \`_copy_data\` returns — that was misleading. Reworded to say what's actually true: the COPY has committed, so concurrent reads proceed while VACUUM runs; the operator's flow run still blocks until VACUUM finishes.

### Tests
**102/102 unit tests pass** in dpp-test (101 prior + 1 new). Both reply threads on #296 posted.

## Test plan
- [ ] \`ci.yml\` (DataPusher+ Integration CI) — quick-dir matrix still green. The narrowed swallow path is exercised by every successful ingestion that goes through the database stage; the re-raise path is covered by the new unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)